### PR TITLE
Implement SMTP Security selection (+ minor code changes)

### DIFF
--- a/class-mail.php
+++ b/class-mail.php
@@ -82,16 +82,9 @@ class Mail {
 			$phpmailer->Password = $this->options->get( 'pass' )->value;
 			$phpmailer->SMTPAuth = $this->options->get( 'auth' )->value;
 
-			$sec = $this->options->get( 'sec' )->value;
-			if ( ! empty( $sec ) ) {
-				switch ( (int) $sec ) {
-					case 1:
-						$phpmailer->SMTPSecure = 'ssl';
-						break;
-					case 2:
-						$phpmailer->SMTPSecure = 'tls';
-						break;
-				}
+			$sec = $this->options->get( 'sec' );
+			if ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'ssl', 'tls' ], true ) ) {
+				$phpmailer->SMTPSecure = $sec->value;
 			}
 
 			$ssl_status = $this->options->get( 'noverifyssl' );

--- a/class-mail.php
+++ b/class-mail.php
@@ -82,6 +82,18 @@ class Mail {
 			$phpmailer->Password = $this->options->get( 'pass' )->value;
 			$phpmailer->SMTPAuth = $this->options->get( 'auth' )->value;
 
+			$sec = $this->options->get( 'sec' )->value;
+			if ( ! empty( $sec ) ) {
+				switch ( (int) $sec ) {
+					case 1:
+						$phpmailer->SMTPSecure = 'ssl';
+						break;
+					case 2:
+						$phpmailer->SMTPSecure = 'tls';
+						break;
+				}
+			}
+
 			$ssl_status = $this->options->get( 'noverifyssl' );
 			if ( ! empty( $ssl_status ) && true === filter_var( $ssl_status->value, FILTER_VALIDATE_BOOLEAN ) ) {
 				$phpmailer->SMTPOptions = [

--- a/class-options.php
+++ b/class-options.php
@@ -67,7 +67,7 @@ class Options {
 			'string' => $value,
 			'd'      => 0,
 		];
-		
+
 		if ( extension_loaded( 'openssl' ) ) {
 			$pl['string'] = openssl_encrypt( $value, 'AES-128-ECB', $this->encryption_key() );
 			$pl['d']      = 1;
@@ -104,7 +104,7 @@ class Options {
 	 *
 	 * @return string Encryption key.
 	 */
-	private function encryption_key () {
+	private function encryption_key() {
 		return SECURE_AUTH_KEY;
 	}
 }

--- a/class-settings.php
+++ b/class-settings.php
@@ -112,9 +112,9 @@ class Settings {
 		);
 
 		$sec = [
-			0 => 'Default',
-			1 => 'SSL',
-			2 => 'TLS',
+			'def' => 'Default',
+			'ssl' => 'SSL',
+			'tls' => 'TLS',
 		];
 
 		$this->settings_field_generator( 'host', __( 'Host', 'wpsimplesmtp' ), 'text', 'smtp.example.com' );

--- a/class-settings.php
+++ b/class-settings.php
@@ -124,7 +124,7 @@ class Settings {
 		$this->settings_field_generator( 'pass', __( 'Password', 'wpsimplesmtp' ), 'password', '' );
 		$this->settings_field_generator( 'from', __( 'Force from', 'wpsimplesmtp' ), 'email', 'do-not-reply@example.com' );
 		$this->settings_field_generator( 'fromname', __( 'Force from name', 'wpsimplesmtp' ), 'text', 'WordPress System' );
-		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'wpsimplesmtp' ), $sec, 'dropdown', '', __( 'If default, the standard for the port number is chosen.', 'wpsimplesmtp' ) );
+		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'wpsimplesmtp' ), $sec, 'dropdown' );
 		$this->settings_field_generator( 'noverifyssl', __( 'Disable SSL Verification', 'wpsimplesmtp' ), 'checkbox', '', __( 'Do not disable this unless you know what you\'re doing.', 'wpsimplesmtp' ) );
 		$this->settings_field_generator( 'log', __( 'Logging', 'wpsimplesmtp' ), 'checkbox', '' );
 	}
@@ -319,7 +319,7 @@ class Settings {
 					case 'dropdown':
 					default:
 						?>
-						<select name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php echo esc_attr( $has_env ); ?>>
+						<select id='wpss_<?php echo esc_attr( $name ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php echo esc_attr( $has_env ); ?>>
 							<?php foreach ( $options as $key => $option ) : ?>
 							<option value='<?php echo esc_attr( $key ); ?>' <?php echo esc_attr( isset( $value ) && (string) $key === (string) $value->value ) ? 'selected' : ''; ?>><?php echo esc_attr( $option ); ?></option>
 							<?php endforeach; ?>

--- a/class-settings.php
+++ b/class-settings.php
@@ -297,7 +297,7 @@ class Settings {
 	 *
 	 * @param string $name        Code name of input.
 	 * @param string $name_pretty Name shown to user.
-	 * @param string $options     Array of possible selections, with the index used as a key.
+	 * @param array  $options     Array of possible selections, with the index used as a key.
 	 * @param string $type        Input element type. Normally 'text'.
 	 * @param string $example     Text shown as a placeholder.
 	 * @param string $subtext     Text displayed underneath input box.

--- a/class-settings.php
+++ b/class-settings.php
@@ -111,6 +111,12 @@ class Settings {
 			'wpsimplesmtp_smtp'
 		);
 
+		$sec = [
+			0 => 'Default',
+			1 => 'SSL',
+			2 => 'TLS',
+		];
+
 		$this->settings_field_generator( 'host', __( 'Host', 'wpsimplesmtp' ), 'text', 'smtp.example.com' );
 		$this->settings_field_generator( 'port', __( 'Port', 'wpsimplesmtp' ), 'number', '587' );
 		$this->settings_field_generator( 'auth', __( 'Authenticate', 'wpsimplesmtp' ), 'checkbox', '' );
@@ -118,6 +124,7 @@ class Settings {
 		$this->settings_field_generator( 'pass', __( 'Password', 'wpsimplesmtp' ), 'password', '' );
 		$this->settings_field_generator( 'from', __( 'Force from', 'wpsimplesmtp' ), 'email', 'do-not-reply@example.com' );
 		$this->settings_field_generator( 'fromname', __( 'Force from name', 'wpsimplesmtp' ), 'text', 'WordPress System' );
+		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'wpsimplesmtp' ), $sec, 'dropdown', '', __( 'If default, the standard for the port number is chosen.', 'wpsimplesmtp' ) );
 		$this->settings_field_generator( 'noverifyssl', __( 'Disable SSL Verification', 'wpsimplesmtp' ), 'checkbox', '', __( 'Do not disable this unless you know what you\'re doing.', 'wpsimplesmtp' ) );
 		$this->settings_field_generator( 'log', __( 'Logging', 'wpsimplesmtp' ), 'checkbox', '' );
 	}
@@ -253,7 +260,7 @@ class Settings {
 	 * @param string $example     Text shown as a placeholder.
 	 * @param string $subtext     Text displayed underneath input box.
 	 */
-	private function settings_field_generator( $name, $name_pretty, $type, $example, $subtext = '' ) {
+	private function settings_field_generator( $name, $name_pretty, $type, $example = '', $subtext = '' ) {
 		$value = $this->options->get( $name );
 
 		add_settings_field(
@@ -275,6 +282,48 @@ class Settings {
 					default:
 						?>
 						<input id='wpss_<?php echo esc_attr( $name ); ?>' class='regular-text ltr' type='<?php echo esc_attr( $type ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' value='<?php echo esc_attr( $value->value ); ?>' placeholder='<?php echo esc_attr( $example ); ?>' <?php echo esc_attr( $has_env ); ?>>
+						<?php
+						break;
+				}
+				echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
+			},
+			'wpsimplesmtp_smtp',
+			'wpsimplesmtp_smtp_section'
+		);
+	}
+
+	/**
+	 * Generates an generic input multi-select.
+	 *
+	 * @param string $name        Code name of input.
+	 * @param string $name_pretty Name shown to user.
+	 * @param string $options     Array of possible selections, with the index used as a key.
+	 * @param string $type        Input element type. Normally 'text'.
+	 * @param string $example     Text shown as a placeholder.
+	 * @param string $subtext     Text displayed underneath input box.
+	 */
+	private function settings_field_generator_multiple( $name, $name_pretty, $options, $type, $example = '', $subtext = '' ) {
+		$value = $this->options->get( $name );
+
+		add_settings_field(
+			'wpssmtp_smtp_' . $name,
+			$name_pretty,
+			function () use ( $name, $value, $options, $type, $example, $subtext ) {
+				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
+				$has_env = '';
+				if ( 'CONFIG' !== $value->source ) {
+					$has_env = 'disabled';
+				}
+
+				switch ( $type ) {
+					case 'dropdown':
+					default:
+						?>
+						<select name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php echo esc_attr( $has_env ); ?>>
+							<?php foreach ( $options as $key => $option ) : ?>
+							<option value='<?php echo esc_attr( $key ); ?>' <?php echo esc_attr( isset( $value ) && (string) $key === (string) $value->value ) ? 'selected' : ''; ?>><?php echo esc_attr( $option ); ?></option>
+							<?php endforeach; ?>
+						</select>
 						<?php
 						break;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,9 @@ These can be either stored in your systems env setup, or in wp-config.php as `de
 * `SMTP_AUTH` (integer, 1 or 0) Pass below credentials to your mail server.
 * `SMTP_USER` (string) The mail username for this account.
 * `SMTP_PASS` (string) The password for the mailer account.
+* `SMTP_FROM` (string) Enforce all emails come from this email address.
+* `SMTP_FROMNAME` (string) Enforce all emails to have a certain email name.
+* `SMTP_SEC` (string) Use a particular email security method (accepts 'def' (default), 'ssl' and 'tls').
 * `SMTP_NOVERIFYSSL` (boolean) Disable validation of the SMTP server certificate (not recommended).
 * `SMTP_LOG` (boolean) Controls the logging capability and visibility.
 
@@ -44,6 +47,9 @@ Yes. Each site can have unique settings, unless overriding is on. The network wi
 Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-simple-smtp) for writing issues and/or making pull requests.
 
 == Changelog ==
+= 0.3.6 =
+* SMTPSecure is now a configurable option ([#11](https://github.com/soup-bowl/wp-simple-smtp/issues/11)).
+
 = 0.3.5 =
 * When openssl is available, the password stored in the database will be encrypted.
 * Added a quick configuration option, to guide SMTP setup (less Googling).

--- a/smtp-config.js
+++ b/smtp-config.js
@@ -91,6 +91,9 @@ function wpss_input_selection( data, name ) {
 		if ( ! document.getElementById( 'wpss_pass' ).disabled ) {
 			document.getElementById( 'wpss_pass' ).value = '';
 		}
+		if ( ! document.getElementById( 'wpss_sec' ).disabled ) {
+			document.getElementById( 'wpss_sec' ).value = ( s.encryption != null ? s.encryption : 'def' );
+		}
 		if ( ! document.getElementById( 'wpss_noverifyssl' ).disabled ) {
 			document.getElementById( 'wpss_noverifyssl' ).checked = false;
 		}

--- a/tests/class-options-test.php
+++ b/tests/class-options-test.php
@@ -33,7 +33,7 @@ class OptionsTest extends TestCase {
 			'password_d' => $e_str['d'],
 		];
 
-		$d_str   = $this->options->maybe_decrypt( $e_col, 'password' );
+		$d_str = $this->options->maybe_decrypt( $e_col, 'password' );
 
 		$this->assertStringContainsString( $string, $d_str, 'Decrypted string matches initially encrypted string.' );
 	}

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Simple SMTP
  * Description:       Adds mail configuration to WordPress in a simple, standardised plugin.
  * Plugin URI:        https://github.com/soup-bowl/simple-smtp
- * Version:           0.3.5
+ * Version:           0.3.6
  * Author:            soup-bowl
  * Author URI:        https://www.soupbowl.io
  * License:           MIT

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -43,7 +43,7 @@ add_action(
 	'admin_enqueue_scripts',
 	function ( $page ) {
 		if ( 'settings_page_wpsimplesmtp' === $page ) {
-			wp_enqueue_script( 'wpss_config', plugin_dir_url( __FILE__ ) . 'smtp-config.js', [ 'jquery', 'wp-i18n' ], '1', true );
+			wp_enqueue_script( 'wpss_config', plugin_dir_url( __FILE__ ) . 'smtp-config.js', [ 'jquery', 'wp-i18n' ], '1.1', true );
 		}
 	}
 );


### PR DESCRIPTION
Provides a dropdown to change the the SMTP security option, as suggested in issue #11. This also adds the option as an environmental input using `SMTP_SEC`.

CodeSniffer was run and provided some suggested changes, and incremented the version.