### PR TITLE
Encryption keycheck failure warnings (#28)

### DIFF
--- a/class-options.php
+++ b/class-options.php
@@ -13,6 +13,11 @@ namespace wpsimplesmtp;
  * Handles the retrieval of system variables.
  */
 class Options {
+	/**
+	 * Test value constant for checking encryption functionality.
+	 *
+	 * @var string
+	 */
 	protected $test_value = 'helloworld';
 
 	/**
@@ -104,7 +109,6 @@ class Options {
 	/**
 	 * Checks the encryption passphrase has not changed.
 	 *
-	 * @param string $string The test string to match.
 	 * @return boolean Represents whether the test value decryption was a success or not.
 	 */
 	public function check_encryption_key() {

--- a/class-options.php
+++ b/class-options.php
@@ -13,6 +13,8 @@ namespace wpsimplesmtp;
  * Handles the retrieval of system variables.
  */
 class Options {
+	protected $test_value = 'helloworld';
+
 	/**
 	 * Gets the setting value. This checks the following in chronological order:
 	 * - Environmental variables (including .env).
@@ -97,6 +99,32 @@ class Options {
 		} else {
 			return $options[ $name ];
 		}
+	}
+
+	/**
+	 * AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.
+	 *
+	 * @param string $string The test string to match.
+	 * @return boolean Represents whether the test value decryption was a success or not.
+	 */
+	public function check_encryption_key() {
+		$codeword = openssl_decrypt( get_option( 'wpssmtp_echk' ), 'AES-128-ECB', $this->encryption_key() );
+
+		if ( $this->test_value === $codeword ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Sets a test string for testing encryption purposes.
+	 */
+	public function set_encryption_test() {
+		update_option(
+			'wpssmtp_echk',
+			openssl_encrypt( $this->test_value, 'AES-128-ECB', $this->encryption_key() )
+		);
 	}
 
 	/**

--- a/class-options.php
+++ b/class-options.php
@@ -102,7 +102,7 @@ class Options {
 	}
 
 	/**
-	 * AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.
+	 * Checks the encryption passphrase has not changed.
 	 *
 	 * @param string $string The test string to match.
 	 * @return boolean Represents whether the test value decryption was a success or not.

--- a/class-options.php
+++ b/class-options.php
@@ -76,6 +76,8 @@ class Options {
 		];
 
 		if ( extension_loaded( 'openssl' ) ) {
+			$this->set_encryption_test();
+
 			$pl['string'] = openssl_encrypt( $value, 'AES-128-ECB', $this->encryption_key() );
 			$pl['d']      = 1;
 		}

--- a/class-settings.php
+++ b/class-settings.php
@@ -279,7 +279,7 @@ class Settings {
 			$options['pass_d'] = $pass_opt['d'];
 		}
 
-		delete_option( 'wpssmtp_keycheck_fail' );
+		$this->reset_encryption_keycheck();
 
 		return $options;
 	}
@@ -483,6 +483,16 @@ class Settings {
 	private function encryption_keycheck() {
 		if ( ! empty( get_option( 'wpssmtp_echk' ) ) && ! $this->options->check_encryption_key() ) {
 			add_option( 'wpssmtp_keycheck_fail', true );
+		}
+	}
+
+	/**
+	 * Resets the encryption warning, if it has been triggered.
+	 */
+	private function reset_encryption_keycheck() {
+		if ( ! empty( get_option( 'wpssmtp_keycheck_fail' ) ) ) {
+			$this->options->set_encryption_test();
+			delete_option( 'wpssmtp_keycheck_fail' );
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,7 @@ Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-sim
 
 == Changelog ==
 = Next =
+* New: Key change detection when SMTP password encryption is used, to warn user the email dispatch may fail ([#28](https://github.com/soup-bowl/wp-simple-smtp/issues/28)).
 * Change: Custom HTML removed in favour of translatable HTML test email. Thanks to [Kebbet](https://github.com/kebbet) for implementation ([#26](https://github.com/soup-bowl/wp-simple-smtp/issues/26)).
 * Fix: JavaScript error when viewing emails ([#24](https://github.com/soup-bowl/wp-simple-smtp/issues/24)).
 

--- a/tests/class-bootstrap.php
+++ b/tests/class-bootstrap.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+$GLOBALS['sbss_temp_store'] = [];
+
 /**
  * Mocks the WordPress add_action function.
  *
@@ -27,21 +29,47 @@ function add_action( $a, $b = '' ) {
 /**
  * Mocks the WordPress get_option function.
  *
- * @param mixed $a Not used.
- * @return string[]
+ * @param mixed $name Key name.
+ * @return mixed
  */
-function get_option( $a ) {
+function get_option( $name ) {
+	global $sbss_temp_store;
+
 	$env_loc = __DIR__ . '/../.env';
 	if ( file_exists( $env_loc ) ) {
 		$dotenv = Dotenv::createImmutable( __DIR__ . '/../' );
 		$dotenv->load( $env_loc );
 	}
 
-	return [
-		'host'     => $_ENV['SMTP_HOST'],
-		'port'     => $_ENV['SMTP_PORT'],
-		'username' => $_ENV['SMTP_USER'],
-		'password' => $_ENV['SMTP_PASS'],
-		'auth'     => $_ENV['SMTP_AUTH'],
-	];
+	switch ( $name ) {
+		case 'wpssmtp_smtp':
+			return [
+				'host'     => $_ENV['SMTP_HOST'],
+				'port'     => $_ENV['SMTP_PORT'],
+				'username' => $_ENV['SMTP_USER'],
+				'password' => $_ENV['SMTP_PASS'],
+				'auth'     => $_ENV['SMTP_AUTH'],
+			];
+		default:
+			if (! empty ( $sbss_temp_store[ $name ] ) ) {
+				return $sbss_temp_store[ $name ];
+			} else {
+				return '';
+			}
+	}
+}
+
+/**
+ * Mocks the WordPress update_option function.
+ *
+ * @param string $name Key name.
+ * @param mixed $value Variable to be stored.
+ * @return mixed
+ */
+function update_option( $name, $value ) {
+	global $sbss_temp_store;
+
+	$sbss_temp_store[ $name ] = $value;
+
+	return true;
 }

--- a/tests/class-options-test.php
+++ b/tests/class-options-test.php
@@ -19,11 +19,26 @@ class OptionsTest extends TestCase {
 	protected $options;
 
 	public function setUp():void {
-		define( 'SECURE_AUTH_KEY', 's7r0237r897d89s69r83289' );
+		if ( ! defined( 'SECURE_AUTH_KEY') ) {
+			define( 'SECURE_AUTH_KEY', 's7r0237r897d89s69r83289' );
+		}
 
 		$this->options = new Options();
 	}
 
+	/**
+	 * Test to check the encryption validation routine is successfully verifying the test key.
+	 */
+	public function test_encryption_validator() {
+		$keyphrase = $this->options->set_encryption_test();
+		$success   = $this->options->check_encryption_key();
+
+		$this->assertTrue( $success );
+	}
+
+	/**
+	 * Runs the encrytion/decryption routine to validate a successful encrypted value store.
+	 */
 	public function test_password_encryption() {
 		$string = 'ab123@*';
 

--- a/tests/class-options-test.php
+++ b/tests/class-options-test.php
@@ -16,10 +16,18 @@ use PHPUnit\Framework\TestCase;
  * Tests the option functionality.
  */
 class OptionsTest extends TestCase {
+	/**
+	 * Options.
+	 *
+	 * @var Options
+	 */
 	protected $options;
 
+	/**
+	 * Constructor.
+	 */
 	public function setUp():void {
-		if ( ! defined( 'SECURE_AUTH_KEY') ) {
+		if ( ! defined( 'SECURE_AUTH_KEY' ) ) {
 			define( 'SECURE_AUTH_KEY', 's7r0237r897d89s69r83289' );
 		}
 

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -77,5 +77,22 @@ add_action(
 	}
 );
 
+/**
+ * Displays plugin errors on admin screen if error criteria is met.
+ */
+function wpsmtp_has_error() {
+	$kses_standard = [
+		'div' => [ 'class' => [] ],
+		'p'   => [],
+	];
+	if ( ! empty( get_option( 'wpssmtp_keycheck_fail' ) ) ) {
+		$notice  = '<div class="error fade"><p>';
+		$notice .= __( 'Encryption keys have changed - Please update the SMTP password to avoid email disruption.', 'simple-smtp' );
+		$notice .= '</p></div>';
+		echo wp_kses( $notice, $kses_standard );
+	}
+}
+add_action( 'admin_notices', 'wpsmtp_has_error' );
+
 register_activation_hook( __FILE__, 'wpsmtp_activation' );
 register_deactivation_hook( __FILE__, 'wpsmtp_deactivation' );

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -82,9 +82,12 @@ add_action(
  */
 function wpsmtp_has_error() {
 	$kses_standard = [
-		'div' => [ 'class' => [] ],
+		'div' => [
+			'class' => [],
+		],
 		'p'   => [],
 	];
+
 	if ( ! empty( get_option( 'wpssmtp_keycheck_fail' ) ) ) {
 		$notice  = '<div class="error fade"><p>';
 		$notice .= __( 'Encryption keys have changed - Please update the SMTP password to avoid email disruption.', 'simple-smtp' );


### PR DESCRIPTION
This PR will warn the user if the conditions are met:

- A password is set in the database using OpenSSL encryption library.
- The user has - for whatever reason - reset the WordPress salts.

Under this condition, the SMTP functionality will ~now~ fail. This will alert the user that the password needs to be re-entered.

PR also removes the condition that a blank SMTP password is encrypted.

Test cases added, and simulated the scenario outlined above to complete success.