### PR TITLE
Log attachments

### DIFF
--- a/class-log.php
+++ b/class-log.php
@@ -143,7 +143,7 @@ class Log {
 		if ( ! empty( $attachments ) ) {
 			$file_collection = [];
 			foreach ( $attachments as $attachment ) {
-				$file_collection[] = new LogAttachment( $attachment );
+				$file_collection[] = ( new LogAttachment() )->unpack( $attachment );
 			}
 
 			return $file_collection;

--- a/class-log.php
+++ b/class-log.php
@@ -9,6 +9,8 @@
 
 namespace wpsimplesmtp;
 
+use wpsimplesmtp\LogAttachment;
+
 use stdClass;
 use WP_Query;
 
@@ -44,11 +46,14 @@ class Log {
 	 * @param string $subject    Subject headline from the email.
 	 * @param string $content    Whatever was inside the dispatched email.
 	 * @param array  $headers    Email headers served alongside the dispatch.
+	 * @param string[] $attachments Location of attachments in the system.
 	 * @param string $timestamp  The time the email was sent.
 	 * @param string $error      Any errors encountered during the exchange.
 	 * @return integer ID of the newly-inserted entry.
 	 */
-	public function new_log_entry( $recipients, $subject, $content, $headers, $timestamp, $error = null ) {
+	public function new_log_entry( $recipients, $subject, $content, $headers, $attachments = [], $timestamp = null, $error = null ) {
+		$timestamp = ( empty( $timestamp ) ) ? current_time( 'mysql' ) : $timestamp;
+
 		$post_id = wp_insert_post(
 			[
 				'post_title'   => $subject,
@@ -58,6 +63,7 @@ class Log {
 				'meta_input'   => [
 					'recipients' => $recipients,
 					'headers'    => $headers,
+					'attachments' => $attachments,
 					'timestamp'  => $timestamp,
 					'error'      => $error,
 				],
@@ -122,6 +128,27 @@ class Log {
 			return floor( $count / $limit );
 		} else {
 			return 1;
+		}
+	}
+
+	/**
+	 * Gets an object collection of attachments, if the entry had them.
+	 *
+	 * @param integer $id ID of the email log entry.
+	 * @return LogAttachment[]|null
+	 */
+	public function get_log_entry_attachments( $id ) {
+		$attachments = get_post_meta( $id, 'attachments', true );
+
+		if ( ! empty( $attachments ) ) {
+			$file_collection = [];
+			foreach ( $attachments as $attachment ) {
+				$file_collection[] = new LogAttachment( $attachment );
+			}
+
+			return $file_collection;
+		} else {
+			return null;
 		}
 	}
 

--- a/class-log.php
+++ b/class-log.php
@@ -42,13 +42,13 @@ class Log {
 	/**
 	 * Creates a new log entry.
 	 *
-	 * @param string $recipients The person(s) who recieved the email.
-	 * @param string $subject    Subject headline from the email.
-	 * @param string $content    Whatever was inside the dispatched email.
-	 * @param array  $headers    Email headers served alongside the dispatch.
+	 * @param string   $recipients The person(s) who recieved the email.
+	 * @param string   $subject    Subject headline from the email.
+	 * @param string   $content    Whatever was inside the dispatched email.
+	 * @param array    $headers    Email headers served alongside the dispatch.
 	 * @param string[] $attachments Location of attachments in the system.
-	 * @param string $timestamp  The time the email was sent.
-	 * @param string $error      Any errors encountered during the exchange.
+	 * @param string   $timestamp  The time the email was sent.
+	 * @param string   $error      Any errors encountered during the exchange.
 	 * @return integer ID of the newly-inserted entry.
 	 */
 	public function new_log_entry( $recipients, $subject, $content, $headers, $attachments = [], $timestamp = null, $error = null ) {
@@ -61,11 +61,11 @@ class Log {
 				'post_status'  => 'publish',
 				'post_type'    => $this->post_type,
 				'meta_input'   => [
-					'recipients' => $recipients,
-					'headers'    => $headers,
+					'recipients'  => $recipients,
+					'headers'     => $headers,
 					'attachments' => $attachments,
-					'timestamp'  => $timestamp,
-					'error'      => $error,
+					'timestamp'   => $timestamp,
+					'error'       => $error,
 				],
 			]
 		);
@@ -124,7 +124,7 @@ class Log {
 		$count = (int) wp_count_posts( $this->post_type )->publish;
 
 		if ( false !== $count ) {
-			$count = $count - intval(1);
+			$count = $count - intval( 1 );
 			return floor( $count / $limit );
 		} else {
 			return 1;

--- a/class-logattachment.php
+++ b/class-logattachment.php
@@ -48,13 +48,19 @@ class LogAttachment {
 	 */
 	protected $extension;
 
+	/**
+	 * Creates a new log attachment object.
+	 *
+	 * @param string $location The location of the tracked file.
+	 * @return self
+	 */
 	public function new( $location ) {
 		$this->location = $location;
 
 		if ( file_exists( $this->location ) ) {
 			$this->exists = true;
 
-			$file = pathinfo( $this->location );
+			$file            = pathinfo( $this->location );
 			$this->basename  = $file['basename'];
 			$this->filename  = $file['filename'];
 			$this->extension = ( isset( $file['extension'] ) ) ? $file['extension'] : '';
@@ -68,26 +74,57 @@ class LogAttachment {
 		return $this;
 	}
 
+	/**
+	 * The file path of the file.
+	 *
+	 * @return string
+	 */
 	public function file_path() {
 		return $this->location;
 	}
 
+	/**
+	 * Check for whether the file currently exists or not.
+	 *
+	 * @return boolean
+	 */
 	public function exists() {
 		return $this->exists;
 	}
 
+	/**
+	 * Gets the file name.
+	 *
+	 * @return string
+	 */
 	public function filename() {
 		return $this->filename;
 	}
 
+	/**
+	 * Returns the filename, plus extension.
+	 *
+	 * @return string
+	 */
 	public function basename() {
 		return $this->basename;
 	}
 
+	/**
+	 * Gets the file extension.
+	 *
+	 * @return string
+	 */
 	public function extension() {
 		return $this->extension;
 	}
 
+	/**
+	 * Takes the stored JSON and unpacks it back into the object.
+	 *
+	 * @param string $input The direct output of the to_string function.
+	 * @return self
+	 */
 	public function unpack( $input ) {
 		$input           = json_decode( $input );
 		$this->location  = $input->location;
@@ -104,12 +141,19 @@ class LogAttachment {
 		return $this;
 	}
 
+	/**
+	 * Returns the current object class as a JSON string.
+	 *
+	 * @return string
+	 */
 	public function to_string() {
-		return json_encode([
-			'location'  => $this->location,
-			'basename'  => $this->basename,
-			'filename'  => $this->filename,
-			'extension' => $this->extension,
-		]);
+		return wp_json_encode(
+			[
+				'location'  => $this->location,
+				'basename'  => $this->basename,
+				'filename'  => $this->filename,
+				'extension' => $this->extension,
+			]
+		);
 	}
 }

--- a/class-logattachment.php
+++ b/class-logattachment.php
@@ -57,7 +57,7 @@ class LogAttachment {
 			$file = pathinfo( $this->location );
 			$this->basename  = $file['basename'];
 			$this->filename  = $file['filename'];
-			$this->extension = $file['extension'];
+			$this->extension = ( isset( $file['extension'] ) ) ? $file['extension'] : '';
 		} else {
 			$this->exists    = false;
 			$this->basename  = '';

--- a/class-logattachment.php
+++ b/class-logattachment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Simple email configuration within WordPress.
+ *
+ * @package sb-simple-smtp
+ * @author soup-bowl <code@soupbowl.io>
+ * @license MIT
+ */
+
+namespace wpsimplesmtp;
+
+/**
+ * Object representation of an email system attachment.
+ */
+class LogAttachment {
+	/**
+	 * File location on the filesystem.
+	 *
+	 * @var string
+	 */
+	protected $location;
+
+	/**
+	 * Whether or not the supplied filepath actually exists.
+	 *
+	 * @var boolean
+	 */
+	protected $exists;
+
+	/**
+	 * File name.
+	 *
+	 * @var string
+	 */
+	protected $filename;
+
+	public function __construct( $location ) {
+		if ( file_exists( $location ) ) {
+			$this->exists = true;
+		} else {
+			$this->exists = false;
+		}
+	}
+
+	public function exists() {
+		return $this->exists;
+	}
+}

--- a/class-logattachment.php
+++ b/class-logattachment.php
@@ -28,21 +28,88 @@ class LogAttachment {
 	protected $exists;
 
 	/**
+	 * File name including extension.
+	 *
+	 * @var string
+	 */
+	protected $basename;
+
+	/**
 	 * File name.
 	 *
 	 * @var string
 	 */
 	protected $filename;
 
-	public function __construct( $location ) {
-		if ( file_exists( $location ) ) {
+	/**
+	 * File extension.
+	 *
+	 * @var string
+	 */
+	protected $extension;
+
+	public function new( $location ) {
+		$this->location = $location;
+
+		if ( file_exists( $this->location ) ) {
 			$this->exists = true;
+
+			$file = pathinfo( $this->location );
+			$this->basename  = $file['basename'];
+			$this->filename  = $file['filename'];
+			$this->extension = $file['extension'];
 		} else {
-			$this->exists = false;
+			$this->exists    = false;
+			$this->basename  = '';
+			$this->filename  = '';
+			$this->extension = '';
 		}
+
+		return $this;
+	}
+
+	public function file_path() {
+		return $this->location;
 	}
 
 	public function exists() {
 		return $this->exists;
+	}
+
+	public function filename() {
+		return $this->filename;
+	}
+
+	public function basename() {
+		return $this->basename;
+	}
+
+	public function extension() {
+		return $this->extension;
+	}
+
+	public function unpack( $input ) {
+		$input           = json_decode( $input );
+		$this->location  = $input->location;
+		$this->basename  = $input->basename;
+		$this->filename  = $input->filename;
+		$this->extension = $input->extension;
+
+		if ( file_exists( $this->location ) ) {
+			$this->exists = true;
+		} else {
+			$this->exists = false;
+		}
+
+		return $this;
+	}
+
+	public function to_string() {
+		return json_encode([
+			'location'  => $this->location,
+			'basename'  => $this->basename,
+			'filename'  => $this->filename,
+			'extension' => $this->extension,
+		]);
 	}
 }

--- a/class-logtable.php
+++ b/class-logtable.php
@@ -105,7 +105,7 @@ class LogTable {
 		$message     = sprintf( __( 'Showing page %1$s of %2$s.', 'simple-smtp' ), $page_cu, $page_co );
 		$nav_buttons = $this->generate_table_buttons( $page, $pages );
 
-		if ( floatval(0) === $page_co ) {
+		if ( floatval( 0 ) === $page_co ) {
 			// Do not display navigation if 0 pages/entries.
 			return;
 		}

--- a/class-mail.php
+++ b/class-mail.php
@@ -131,7 +131,7 @@ class Mail {
 
 			$attachments = [];
 			foreach ( $parameters['attachments'] as $attachment ) {
-				$attachments[] = ( new LogAttachment )->new( $attachment )->to_string();
+				$attachments[] = ( new LogAttachment() )->new( $attachment )->to_string();
 			}
 
 			$wpss_mail_id = $this->log->new_log_entry(

--- a/class-mail.php
+++ b/class-mail.php
@@ -11,6 +11,7 @@ namespace wpsimplesmtp;
 
 use wpsimplesmtp\Options;
 use wpsimplesmtp\Log;
+use wpsimplesmtp\LogAttachment;
 
 /**
  * Configures PHPMailer to use our settings rather than the default.
@@ -128,12 +129,17 @@ class Mail {
 		if ( true === filter_var( $this->options->get( 'log' )->value, FILTER_VALIDATE_BOOLEAN ) ) {
 			$recipient_array = ( is_array( $parameters['to'] ) ) ? $parameters['to'] : [ $parameters['to'] ];
 
+			$attachments = [];
+			foreach ( $parameters['attachments'] as $attachment ) {
+				$attachments[] = ( new LogAttachment )->new( $attachment )->to_string();
+			}
+
 			$wpss_mail_id = $this->log->new_log_entry(
 				wp_json_encode( $recipient_array ),
 				$parameters['subject'],
 				$parameters['message'],
 				wp_json_encode( $parameters['headers'] ),
-				$parameters['attachments']
+				$attachments
 			);
 		}
 

--- a/class-mail.php
+++ b/class-mail.php
@@ -133,7 +133,7 @@ class Mail {
 				$parameters['subject'],
 				$parameters['message'],
 				wp_json_encode( $parameters['headers'] ),
-				current_time( 'mysql' )
+				$parameters['attachments']
 			);
 		}
 

--- a/class-settings.php
+++ b/class-settings.php
@@ -471,7 +471,7 @@ class Settings {
 													<ol>
 														<?php foreach ( $attachments as $attachment ) : ?>
 															<li>
-																<?php echo $attachment->basename(); ?>
+																<?php echo esc_html( $attachment->basename() ); ?>
 																<?php if ( ! $attachment->exists() ) : ?>
 																	<span class="wpsmtp-badge wpsmtp-badge-warning"><?php esc_html_e( 'File missing', 'simple-smtp' ); ?></span>
 																<?php endif; ?>

--- a/class-settings.php
+++ b/class-settings.php
@@ -415,6 +415,7 @@ class Settings {
 	 */
 	private function render_email_view( $id ) {
 		$log        = $this->log->get_log_entry_by_id( $id );
+		$attachments = $this->log->get_log_entry_attachments( $id );
 		$recset     = ( in_array( (int) $id, get_option( 'wpss_resent', [] ), true ) ) ? ' disabled' : '';
 		$resend_url = add_query_arg(
 			[

--- a/class-settings.php
+++ b/class-settings.php
@@ -243,10 +243,18 @@ class Settings {
 	 * @return boolean
 	 */
 	public function resend_email( $email_id ) {
-		$email      = $this->log->get_log_entry_by_id( $email_id );
-		$recipients = implode( ', ', json_decode( get_post_meta( $email->ID, 'recipients', true ) ) );
-		$headers    = json_decode( get_post_meta( $email->ID, 'headers', true ) );
-		$opts       = get_option( 'wpss_resent', [] );
+		$email       = $this->log->get_log_entry_by_id( $email_id );
+		$attachments = $this->log->get_log_entry_attachments( $email_id );
+		$recipients  = implode( ', ', json_decode( get_post_meta( $email->ID, 'recipients', true ) ) );
+		$headers     = json_decode( get_post_meta( $email->ID, 'headers', true ) );
+		$opts        = get_option( 'wpss_resent', [] );
+
+		$attachpaths = [];
+		foreach ( $attachments as $attachment ) {
+			if ( $attachment->exists() ) {
+				$attachpaths[] = $attachment->file_path();
+			}
+		}
 
 		if ( isset( $email ) && ! in_array( $email_id, $opts, true ) ) {
 			$opts[] = $email_id;
@@ -256,7 +264,8 @@ class Settings {
 				$recipients,
 				$email->post_title,
 				$email->post_content,
-				$headers
+				$headers,
+				$attachpaths
 			);
 
 			return true;

--- a/class-settings.php
+++ b/class-settings.php
@@ -470,7 +470,12 @@ class Settings {
 													<?php esc_html_e( 'Attachment(s)', 'simple-smtp' ); ?>:
 													<ol>
 														<?php foreach ( $attachments as $attachment ) : ?>
-															<li><?php echo $attachment->basename(); ?></li>
+															<li>
+																<?php echo $attachment->basename(); ?>
+																<?php if ( ! $attachment->exists() ) : ?>
+																	<span class="wpsmtp-badge wpsmtp-badge-warning"><?php esc_html_e( 'File missing', 'simple-smtp' ); ?></span>
+																<?php endif; ?>
+															</li>
 														<?php endforeach; ?>
 													</ol>
 												</div>

--- a/class-settings.php
+++ b/class-settings.php
@@ -226,7 +226,7 @@ class Settings {
 				// translators: %s is the website name.
 				sprintf( __( 'Test email from %s', 'simple-smtp' ), get_bloginfo( 'name' ) ),
 				$content,
-				[ 'x-test: WP SMTP', $content_type ]
+				[ 'x-test: WP SMTP', $content_type ],
 			);
 
 			wp_safe_redirect( admin_url( 'options-general.php?page=wpsimplesmtp' ) );
@@ -414,10 +414,10 @@ class Settings {
 	 * @return void Prints to page.
 	 */
 	private function render_email_view( $id ) {
-		$log        = $this->log->get_log_entry_by_id( $id );
+		$log         = $this->log->get_log_entry_by_id( $id );
 		$attachments = $this->log->get_log_entry_attachments( $id );
-		$recset     = ( in_array( (int) $id, get_option( 'wpss_resent', [] ), true ) ) ? ' disabled' : '';
-		$resend_url = add_query_arg(
+		$recset      = ( in_array( (int) $id, get_option( 'wpss_resent', [] ), true ) ) ? ' disabled' : '';
+		$resend_url  = add_query_arg(
 			[
 				'eid'     => $id,
 				'ssnonce' => wp_create_nonce( 'wpss_action' ),
@@ -456,6 +456,16 @@ class Settings {
 										<div id="misc-publishing-actions">
 											<div class="misc-pub-section"><?php esc_html_e( 'Recipient(s)', 'simple-smtp' ); ?>: <strong><?php echo esc_html( $recipients ); ?></strong></div>
 											<div class="misc-pub-section"><?php esc_html_e( 'Date sent', 'simple-smtp' ); ?>: <strong><?php echo esc_html( $date ); ?></strong></div>
+											<?php if ( ! empty( $attachments ) ) : ?>
+												<div class="misc-pub-section">
+													<?php esc_html_e( 'Attachment(s)', 'simple-smtp' ); ?>:
+													<ol>
+														<?php foreach ( $attachments as $attachment ) : ?>
+															<li><?php echo $attachment->basename(); ?></li>
+														<?php endforeach; ?>
+													</ol>
+												</div>
+											<?php endif; ?>
 										</div>
 										<div class="clear"></div>
 									</div>

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
 			"class-options.php",
 			"class-mail.php",
 			"class-log.php",
-			"class-logtable.php"
+			"class-logtable.php",
+			"class-logattachment.php"
 		]
     },
 	"require-dev": {

--- a/smtp-config.css
+++ b/smtp-config.css
@@ -1,0 +1,36 @@
+.wpsmtp-badge {
+	display: inline-block;
+	padding: .25em .4em;
+	padding-right: .6em;
+    padding-left: .6em;
+    font-size: 75%;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+	border-radius: 10rem;
+	
+	color: #fff;
+    background-color: #6c757d;
+}
+
+.wpsmtp-badge.wpsmtp-badge-info {
+	color: #fff;
+    background-color: #17a2b8;
+}
+
+.wpsmtp-badge.wpsmtp-badge-success {
+	color: #fff;
+    background-color: #28a745;
+}
+
+.wpsmtp-badge.wpsmtp-badge-warning {
+	color: #212529;
+    background-color: #ffc107;
+}
+
+.wpsmtp-badge.wpsmtp-badge-danger {
+    color: #fff;
+    background-color: #dc3545;
+}

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -42,6 +42,7 @@ add_action(
 	'admin_enqueue_scripts',
 	function ( $page ) {
 		if ( 'settings_page_wpsimplesmtp' === $page ) {
+			wp_enqueue_style( 'wpss_admin_css', plugin_dir_url( __FILE__ ) . 'smtp-config.css', [], '1.0' );
 			wp_enqueue_script( 'wpss_config', plugin_dir_url( __FILE__ ) . 'smtp-config.js', [ 'jquery', 'wp-i18n' ], '1.2', true );
 			wp_set_script_translations( 'wpss_config', 'simple-smtp' );
 		}


### PR DESCRIPTION
This PR adds the ability for Simple SMTP to track attachments, and will load them in when a resend request is made.

This includes:
- Tracking of attachments stored in the system.
- Marking and handling attachments that have since been disposed of.
- Visual indicator of attachments in the view dialog.

![image](https://user-images.githubusercontent.com/11209477/106375450-fcea2100-6383-11eb-8693-ff71b2642f68.png)
