### PR TITLE
Disable emails (fixes #9)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 			"src/settings/class-mailview.php",
 			"src/mail/class-mail.php",
 			"src/mail/class-mailtest.php",
+			"src/mail/class-maildisable.php",
 			"src/log/class-log.php",
 			"src/log/class-logservice.php",
 			"src/log/class-logtable.php",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,11 @@
         <exclude-pattern>class-log.php</exclude-pattern>
     </rule>
 
+	<!-- Happy to hear alternatives. This was the best I could conceive -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
+		<exclude-pattern>wp-simple-smtp.php</exclude-pattern>
+    </rule>
+
 	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
 		<exclude-pattern>*/*</exclude-pattern>
 	</rule>

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ These can be either stored in your systems env setup, or in wp-config.php as `de
 * `SMTP_SEC` (string) Use a particular email security method (accepts 'def' (default), 'ssl' and 'tls').
 * `SMTP_NOVERIFYSSL` (boolean) Disable validation of the SMTP server certificate (not recommended).
 * `SMTP_LOG` (boolean) Controls the logging capability and visibility.
+* `SMTP_DISABLE` (boolean) Disables the mailer. They will still be logged if enabled, but won't send out.
 
 It is recommended to store at least `SMTP_PASS` in your wp-config.php file (with the correct file permissions set). If the openssl extension is available, the plugin will attempt to encrypt the password in the database.
 

--- a/src/log/class-logtable.php
+++ b/src/log/class-logtable.php
@@ -62,6 +62,7 @@ class LogTable {
 		if ( ! empty( $entries ) ) {
 			foreach ( $entries as $entry ) {
 				$error      = get_post_meta( $entry->get_id(), 'error', true );
+				$error      = ( 'WPSS_MAIL_OFF' === $error ) ? __( 'Email was disabled at this time.', 'simple-smtp' ) : $error;
 				$recipients = implode( ', ', $entry->get_recipients() );
 				$actions    = $this->render_log_entry_buttons( $entry );
 				$date       = gmdate( get_option( 'time_format' ) . ', ' . get_option( 'date_format' ), strtotime( $entry->get_timestamp() ) );

--- a/src/mail/class-maildisable.php
+++ b/src/mail/class-maildisable.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Simple email configuration within WordPress.
+ *
+ * @package sb-simple-smtp
+ * @author soup-bowl <code@soupbowl.io>
+ * @license MIT
+ */
+
+namespace wpsimplesmtp;
+
+if ( ! class_exists( 'PHPMailer', false ) ) {
+	require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+}
+
+/**
+ * To kill off the email functionality, we override the PHPMailer global that WordPress is using with our extended
+ * PHPMailer. This allows us to replace the send function with a custom exception, that will still act like everything
+ * is normal, right up until the dispatch where a custom exception is thrown. Means the users can re-send their emails
+ * once the disabled lock is lifted. Neat!
+ */
+class MailDisable extends \PHPMailer\PHPMailer\PHPMailer {
+	/**
+	 * Disables the PHPMailer send functionality, and forces an Exception instead.
+	 *
+	 * @throws \PHPMailer\PHPMailer\Exception Disabled email message.
+	 */
+	public function send() {
+		throw new \PHPMailer\PHPMailer\Exception( __( 'Emails are currently disabled.', 'simple-smtp' ) );
+	}
+}

--- a/src/mail/class-maildisable.php
+++ b/src/mail/class-maildisable.php
@@ -26,6 +26,6 @@ class MailDisable extends \PHPMailer\PHPMailer\PHPMailer {
 	 * @throws \PHPMailer\PHPMailer\Exception Disabled email message.
 	 */
 	public function send() {
-		throw new \PHPMailer\PHPMailer\Exception( __( 'Emails are currently disabled.', 'simple-smtp' ) );
+		throw new \PHPMailer\PHPMailer\Exception( 'WPSS_MAIL_OFF' );
 	}
 }

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -154,6 +154,7 @@ class Settings {
 		$this->settings_field_generator( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', 'WordPress System' );
 		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'simple-smtp' ), $sec, 'dropdown' );
 		$this->settings_field_generator( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), 'checkbox', '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+		$this->settings_field_generator( 'disable', __( 'Disable Emails', 'simple-smtp' ), 'checkbox', '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ) );
 		$this->settings_field_generator( 'log', __( 'Logging', 'simple-smtp' ), 'checkbox', '' );
 	}
 

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -19,12 +19,26 @@
 use wpsimplesmtp\LogService;
 use wpsimplesmtp\Settings;
 use wpsimplesmtp\Mail;
+use wpsimplesmtp\MailDisable;
 use wpsimplesmtp\Mailtest;
+use wpsimplesmtp\Options;
 
 /**
  * Autoloader.
  */
 require_once __DIR__ . '/vendor/autoload.php';
+
+// Override and disable emails if the user has disabled them.
+$disabled = ( new Options() )->get( 'disable' );
+if ( ! empty( $disabled ) && true === filter_var( $disabled->value, FILTER_VALIDATE_BOOLEAN ) ) {
+	add_action(
+		'plugins_loaded',
+		function() {
+			global $phpmailer;
+			$phpmailer = new MailDisable();
+		}
+	);
+}
 
 if ( is_admin() ) {
 	new Settings();
@@ -95,6 +109,14 @@ function wpsmtp_has_error() {
 	if ( ! empty( get_option( 'wpssmtp_keycheck_fail' ) ) ) {
 		$notice  = '<div class="error fade"><p>';
 		$notice .= __( 'Encryption keys have changed - Please update the SMTP password to avoid email disruption.', 'simple-smtp' );
+		$notice .= '</p></div>';
+		echo wp_kses( $notice, $kses_standard );
+	}
+
+	$disabled = ( new Options() )->get( 'disable' );
+	if ( ! empty( $disabled ) && true === filter_var( $disabled->value, FILTER_VALIDATE_BOOLEAN ) ) {
+		$notice  = '<div class="error fade"><p>';
+		$notice .= __( 'Emails have been disabled. Please visit the Mail settings if you wish to re-enable them.', 'simple-smtp' );
 		$notice .= '</p></div>';
 		echo wp_kses( $notice, $kses_standard );
 	}


### PR DESCRIPTION
Allows the user to disable emails. PR solution overrides the PHPmailer send function to immediately reply with an exception. This is picked up in the close of the wp_mail function, and falls under the fail condition operation already implemented.