### PR TITLE
Adjusted labels for clarity and accessibility. 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mail,email,smtp,dispatch,sender
 Requires at least: 4.9
 Tested up to: 5.8
 Requires PHP: 7.0
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: MIT
 
 Adds a simple mail configuration panel into your WordPress installation. Supports logging and config variables.
@@ -72,6 +72,9 @@ To help diagnose disabled input boxes, when the WordPress site is in [debugging 
 Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-simple-smtp) for writing issues and/or making pull requests.
 
 == Changelog ==
+= 1.2.2 =
+* Change: Input boxes clearer and more WordPress-standardised ([#51](https://github.com/soup-bowl/wp-simple-smtp/issues/51), [#52](https://github.com/soup-bowl/wp-simple-smtp/pull/52)).
+
 = 1.2.1 =
 * Change: Multisite listing table improvements. Thanks to [Kebbet](https://github.com/kebbet) ([#50](https://github.com/soup-bowl/wp-simple-smtp/issues/50)).
 * Fix: Line break issue when viewing emails in the site log. Thanks to [Kebbet](https://github.com/kebbet) [#47](https://github.com/soup-bowl/wp-simple-smtp/issues/47).

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -71,17 +71,23 @@ class Multisite extends Settings {
 			'wpsimplesmtp_smtp_ms'
 		);
 
-		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com', '', true );
-		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587', '', true );
-		$this->generate_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '', '', true );
-		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com', '', true );
-		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '', '', true );
-		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com', '', true );
-		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
-		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), '', '', true );
-		$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ), true );
-		$this->generate_checkbox( 'disable', __( 'Disable Emails', 'simple-smtp' ), '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ), true );
-		$this->generate_checkbox( 'log', __( 'Logging', 'simple-smtp' ), '', '', true );
+		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
+		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ) );
+		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
+		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
+		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
+		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ) );
+		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
+		$this->generate_checkbox_area(
+			'adt',
+			__( 'Options', 'simple-smtp' ),
+			function() {
+				$this->generate_checkbox( 'disable', __( 'Disable email services.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Enable logging capabilities.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced).', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+			}
+		);
 
 		add_settings_field(
 			'wpssmtp_smtp_siteselection',

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -73,7 +73,7 @@ class Multisite extends Settings {
 
 		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
 		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ) );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password.', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
 		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -76,14 +76,14 @@ class Multisite extends Settings {
 		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
-		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
-		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ) );
+		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
+		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ) );
 		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
 		$this->generate_checkbox_area(
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, all multisite email services will be disabled.' ,'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, all multisite email services will be disabled.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'log', __( 'Log all sent emails to the database', 'simple-smtp' ), __( 'Works with the WordPress privacy features.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -73,7 +73,7 @@ class Multisite extends Settings {
 
 		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
 		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password.', 'simple-smtp' ) );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
 		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
@@ -83,9 +83,9 @@ class Multisite extends Settings {
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services.', 'simple-smtp' ) );
-				$this->generate_checkbox( 'log', __( 'Enable logging capabilities.', 'simple-smtp' ) );
-				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced).', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Enable logging capabilities', 'simple-smtp' ) );
+				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}
 		);
 

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -26,7 +26,7 @@ class Multisite extends Settings {
 	 * Registers the relevant WordPress hooks upon creation.
 	 */
 	public function __construct() {
-		parent::__construct( 'wpsimplesmtp_smtp_ms', 'wpsimplesmtp_ms_adminaccess_section' );
+		parent::__construct( true, 'wpsimplesmtp_smtp_ms', 'wpsimplesmtp_ms_adminaccess_section' );
 
 		add_action( 'network_admin_menu', [ &$this, 'add_network_menu' ] );
 		add_action( 'admin_init', [ &$this, 'network_settings_init' ] );
@@ -71,17 +71,17 @@ class Multisite extends Settings {
 			'wpsimplesmtp_smtp_ms'
 		);
 
-		$this->settings_field_generator( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com', '', true );
-		$this->settings_field_generator( 'port', __( 'Port', 'simple-smtp' ), 'number', '587', '', true );
-		$this->settings_field_generator( 'auth', __( 'Authenticate', 'simple-smtp' ), 'checkbox', '', '', true );
-		$this->settings_field_generator( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com', '', true );
-		$this->settings_field_generator( 'pass', __( 'Password', 'simple-smtp' ), 'password', '', '', true );
-		$this->settings_field_generator( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com', '', true );
-		$this->settings_field_generator( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
-		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), 'dropdown', '', '', true );
-		$this->settings_field_generator( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), 'checkbox', '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ), true );
-		$this->settings_field_generator( 'disable', __( 'Disable Emails', 'simple-smtp' ), 'checkbox', '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ), true );
-		$this->settings_field_generator( 'log', __( 'Logging', 'simple-smtp' ), 'checkbox', '', '', true );
+		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com', '', true );
+		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587', '', true );
+		$this->generate_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '', '', true );
+		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com', '', true );
+		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '', '', true );
+		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com', '', true );
+		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
+		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), '', '', true );
+		$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ), true );
+		$this->generate_checkbox( 'disable', __( 'Disable Emails', 'simple-smtp' ), '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ), true );
+		$this->generate_checkbox( 'log', __( 'Logging', 'simple-smtp' ), '', '', true );
 
 		add_settings_field(
 			'wpssmtp_smtp_siteselection',

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -83,8 +83,8 @@ class Multisite extends Settings {
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ) );
-				$this->generate_checkbox( 'log', __( 'Enable logging capabilities', 'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, all multisite email services will be disabled.' ,'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Log all sent emails to the database', 'simple-smtp' ), __( 'Works with the WordPress privacy features.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}
 		);

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -77,7 +77,7 @@ class Multisite extends Settings {
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
 		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
-		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ) );
+		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail sender name', 'simple-smtp' ) );
 		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
 		$this->generate_checkbox_area(
 			'adt',

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -124,7 +124,7 @@ class Settings {
 				}
 
 				?>
-				<label for="wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]">
+				<label for='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]'>
 					<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
 					<?php echo esc_html( $alongside_text ); ?>
 				</label>

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -14,6 +14,13 @@ namespace wpsimplesmtp;
  */
 class Settings {
 	/**
+	 * For settings generator - Multisite modifier.
+	 *
+	 * @var boolean
+	 */
+	protected $ms;
+
+	/**
 	 * For settings generator - Page assignation.
 	 *
 	 * @var string
@@ -30,10 +37,12 @@ class Settings {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $page    For settings generator - Page assignation.
-	 * @param string $section For settings generator - Section assignation.
+	 * @param boolean $ms      For settings generator - Multisite modifier.
+	 * @param string  $page    For settings generator - Page assignation.
+	 * @param string  $section For settings generator - Section assignation.
 	 */
-	public function __construct( $page = 'wpsimplesmtp_smtp', $section = 'wpsimplesmtp_smtp_section' ) {
+	public function __construct( $ms = false, $page = 'wpsimplesmtp_smtp', $section = 'wpsimplesmtp_smtp_section' ) {
+		$this->ms      = $ms;
 		$this->page    = $page;
 		$this->section = $section;
 	}
@@ -54,40 +63,70 @@ class Settings {
 	/**
 	 * Generates an generic input box.
 	 *
-	 * @param string  $name        Code name of input.
-	 * @param string  $name_pretty Name shown to user.
-	 * @param string  $type        Input element type. Normally 'text'.
-	 * @param string  $example     Text shown as a placeholder.
-	 * @param string  $subtext     Text displayed underneath input box.
-	 * @param boolean $ms_mode     Whether the settings are being generated for multisite/network purposes.
+	 * @param string $name        Code name of input.
+	 * @param string $name_pretty Name shown to user.
+	 * @param string $type        Input element type. Normally 'text'.
+	 * @param string $example     Text shown as a placeholder.
+	 * @param string $subtext     Text displayed underneath input box.
 	 */
-	public function settings_field_generator( $name, $name_pretty, $type, $example = '', $subtext = '', $ms_mode = false ) {
-		$value = $this->options->get( $name, true, $ms_mode );
+	public function generate_generic_field( $name, $name_pretty, $type = 'text', $example = '', $subtext = '' ) {
+		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $value, $type, $example, $subtext, $ms_mode ) {
+			function () use ( $name, $value, $type, $example, $subtext ) {
 				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
 				$has_env = '';
-				if ( ! $ms_mode && 'CONFIG' !== $value->source ) {
+				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 					$has_env = 'disabled';
 				}
 
-				switch ( $type ) {
-					case 'checkbox':
-						?>
-						<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
-						<?php
-						break;
-					default:
-						?>
-						<input id='wpss_<?php echo esc_attr( $name ); ?>' class='regular-text ltr' type='<?php echo esc_attr( $type ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' value='<?php echo esc_attr( $value->value ); ?>' placeholder='<?php echo esc_attr( $example ); ?>' <?php echo esc_attr( $has_env ); ?>>
-						<?php
-						break;
+				?>
+				<input id='wpss_<?php echo esc_attr( $name ); ?>' class='regular-text ltr' type='<?php echo esc_attr( $type ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' value='<?php echo esc_attr( $value->value ); ?>' placeholder='<?php echo esc_attr( $example ); ?>' <?php echo esc_attr( $has_env ); ?>>
+				<?php
+
+				if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					echo wp_kses( $value->source, [] );
 				}
 
-				if ( ! $ms_mode && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				if ( ! empty( $subtext ) ) {
+					echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
+				}
+			},
+			$this->page,
+			$this->section,
+			[
+				'label_for' => 'wpss_' . esc_attr( $name ),
+			]
+		);
+	}
+
+	/**
+	 * Generates an generic input box.
+	 *
+	 * @param string $name        Code name of input.
+	 * @param string $name_pretty Name shown to user.
+	 * @param string $subtext     Text displayed underneath input box.
+	 */
+	public function generate_checkbox( $name, $name_pretty, $subtext = '' ) {
+		$value = $this->options->get( $name, true, $this->ms );
+
+		add_settings_field(
+			'wpssmtp_smtp_' . $name,
+			$name_pretty,
+			function () use ( $name, $value, $subtext ) {
+				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
+				$has_env = '';
+				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
+					$has_env = 'disabled';
+				}
+
+				?>
+				<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
+				<?php
+
+				if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo wp_kses( $value->source, [] );
 				}
 
@@ -106,39 +145,31 @@ class Settings {
 	/**
 	 * Generates an generic input multi-select.
 	 *
-	 * @param string  $name        Code name of input.
-	 * @param string  $name_pretty Name shown to user.
-	 * @param array   $options     Array of possible selections, with the index used as a key.
-	 * @param string  $type        Input element type. Normally 'text'.
-	 * @param string  $example     Text shown as a placeholder.
-	 * @param string  $subtext     Text displayed underneath input box.
-	 * @param boolean $ms_mode     Whether the settings are being generated for multisite/network purposes.
+	 * @param string $name        Code name of input.
+	 * @param string $name_pretty Name shown to user.
+	 * @param array  $options     Array of possible selections, with the index used as a key.
+	 * @param string $subtext     Text displayed underneath input box.
 	 */
-	public function settings_field_generator_multiple( $name, $name_pretty, $options, $type, $example = '', $subtext = '', $ms_mode = false ) {
-		$value = $this->options->get( $name, true, $ms_mode );
+	public function generate_selection( $name, $name_pretty, $options, $subtext = '' ) {
+		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $value, $options, $type, $example, $subtext, $ms_mode ) {
+			function () use ( $name, $value, $options, $subtext ) {
 				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
 				$has_env = '';
-				if ( ! $ms_mode && 'CONFIG' !== $value->source ) {
+				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 					$has_env = 'disabled';
 				}
 
-				switch ( $type ) {
-					case 'dropdown':
-					default:
-						?>
-						<select id='wpss_<?php echo esc_attr( $name ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php echo esc_attr( $has_env ); ?>>
-							<?php foreach ( $options as $key => $option ) : ?>
-							<option value='<?php echo esc_attr( $key ); ?>' <?php echo esc_attr( isset( $value ) && (string) $key === (string) $value->value ) ? 'selected' : ''; ?>><?php echo esc_attr( $option ); ?></option>
-							<?php endforeach; ?>
-						</select>
-						<?php
-						break;
-				}
+				?>
+				<select id='wpss_<?php echo esc_attr( $name ); ?>' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php echo esc_attr( $has_env ); ?>>
+					<?php foreach ( $options as $key => $option ) : ?>
+					<option value='<?php echo esc_attr( $key ); ?>' <?php echo esc_attr( isset( $value ) && (string) $key === (string) $value->value ) ? 'selected' : ''; ?>><?php echo esc_attr( $option ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<?php
 				echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
 			},
 			$this->page,

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -96,7 +96,10 @@ class Settings {
 				}
 			},
 			$this->page,
-			$this->section
+			$this->section,
+			[
+				'label_for' => 'wpss_' . esc_attr( $name ),
+			]
 		);
 	}
 
@@ -139,7 +142,10 @@ class Settings {
 				echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
 			},
 			$this->page,
-			$this->section
+			$this->section,
+			[
+				'label_for' => 'wpss_' . esc_attr( $name ),
+			]
 		);
 	}
 

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -87,7 +87,7 @@ class Settings {
 				<?php
 
 				if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					echo wp_kses( $value->source, [] );
+					echo wp_kses( "<span class='wpsmtp-badge wpsmtp-badge-info'>{$value->source}</span>", [ 'span' => [ 'class' => [] ] ] );
 				}
 
 				if ( ! empty( $subtext ) ) {
@@ -109,7 +109,7 @@ class Settings {
 	 * @param string $name_pretty Name shown to user.
 	 * @param string $subtext     Text displayed underneath input box.
 	 */
-	public function generate_checkbox( $name, $name_pretty, $subtext = '' ) {
+	public function generate_unique_checkbox( $name, $name_pretty, $subtext = '' ) {
 		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
@@ -127,7 +127,7 @@ class Settings {
 				<?php
 
 				if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					echo wp_kses( $value->source, [] );
+					echo wp_kses( "<span class='wpsmtp-badge wpsmtp-badge-info'>{$value->source}</span>", [ 'span' => [ 'class' => [] ] ] );
 				}
 
 				if ( ! empty( $subtext ) ) {
@@ -140,6 +140,58 @@ class Settings {
 				'label_for' => 'wpss_' . esc_attr( $name ),
 			]
 		);
+	}
+
+	/**
+	 * Generates a settings area for multiple checkbox placements.
+	 *
+	 * @param string   $name        Code name of input.
+	 * @param string   $name_pretty Name shown to user.
+	 * @param callback $callback    Function is called within the fieldest.
+	 */
+	public function generate_checkbox_area( $name, $name_pretty, $callback ) {
+		add_settings_field(
+			'wpssmtp_smtp_' . $name,
+			$name_pretty,
+			function() use ( &$callback ) {
+				?>
+				<fieldset>
+					<?php call_user_func( $callback ); ?>
+				</fieldset>
+				<?php
+			},
+			$this->page,
+			$this->section
+		);
+	}
+
+	/**
+	 * Generates a checkbox without WordPress settings API for use within generate_checkbox_area callback.
+	 *
+	 * @param string $name        Code name of input.
+	 * @param string $name_pretty Name shown to user.
+	 * @param string $subtext     Text displayed underneath input box.
+	 */
+	public function generate_checkbox( $name, $name_pretty, $subtext = '' ) {
+		$value   = $this->options->get( $name, true, $this->ms );
+		$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
+		$has_env = '';
+		if ( ! $this->ms && 'CONFIG' !== $value->source ) {
+			$has_env = 'disabled';
+		}
+
+		$debuginfo = '';
+		if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$debuginfo = "<span class='wpsmtp-badge wpsmtp-badge-info'>{$value->source}</span>";
+		}
+
+		?>
+		<label for='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]'>
+			<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
+			<?php echo esc_html( $name_pretty ); ?> <?php echo wp_kses( $debuginfo, [ 'span' => [ 'class' => [] ] ] ); ?>
+			<?php echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] ); ?>
+		</label><br>
+		<?php
 	}
 
 	/**

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -64,20 +64,20 @@ class Settings {
 	 * Generates an generic input box.
 	 *
 	 * @param string $name        Code name of input.
-	 * @param string $name_pretty Name shown to user.
-	 * @param string $type        Input element type. Normally 'text'.
-	 * @param string $example     Text shown as a placeholder.
-	 * @param string $subtext     Text displayed underneath input box.
+	 * @param string $name_pretty Left-side column name shown to user.
+	 * @param string $type        Override text input element with number, password, email, etc.
+	 * @param string $example     Content to be shown as a placeholder.
+	 * @param string $description Text displayed underneath the input box.
 	 */
-	public function generate_generic_field( $name, $name_pretty, $type = 'text', $example = '', $subtext = '' ) {
+	public function generate_generic_field( $name, $name_pretty, $type = 'text', $example = '', $description = '' ) {
 		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $value, $type, $example, $subtext ) {
-				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
-				$has_env = '';
+			function () use ( $name, $value, $type, $example, $description ) {
+				$description = ( ! empty( $description ) ) ? "<p class='description'>{$description}</p>" : '';
+				$has_env     = '';
 				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 					$has_env = 'disabled';
 				}
@@ -90,8 +90,8 @@ class Settings {
 					echo wp_kses( "<span class='wpsmtp-badge wpsmtp-badge-info'>{$value->source}</span>", [ 'span' => [ 'class' => [] ] ] );
 				}
 
-				if ( ! empty( $subtext ) ) {
-					echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
+				if ( ! empty( $description ) ) {
+					echo wp_kses( $description, [ 'p' => [ 'class' => [] ] ] );
 				}
 			},
 			$this->page,
@@ -103,22 +103,22 @@ class Settings {
 	}
 
 	/**
-	 * Generates an generic input box.
+	 * Generates a singular checkbox field.
 	 *
-	 * @param string $name        Code name of input.
-	 * @param string $name_pretty Left-hand column name shown to user.
-	 * @param string $description Appears alongside the checkbox.
-	 * @param string $subtext     Text displayed underneath input box.
+	 * @param string $name           Code name of input.
+	 * @param string $name_pretty    Left-side column name shown to user.
+	 * @param string $alongside_text Appears alongside the checkbox.
+	 * @param string $description    Text displayed underneath the input box.
 	 */
-	public function generate_unique_checkbox( $name, $name_pretty, $description = '', $subtext = '' ) {
+	public function generate_unique_checkbox( $name, $name_pretty, $alongside_text = '', $description = '' ) {
 		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $description, $value, $subtext ) {
-				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
-				$has_env = '';
+			function () use ( $name, $alongside_text, $value, $description ) {
+				$description = ( ! empty( $description ) ) ? "<p class='description'>{$description}</p>" : '';
+				$has_env     = '';
 				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 					$has_env = 'disabled';
 				}
@@ -126,7 +126,7 @@ class Settings {
 				?>
 				<label for="wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]">
 					<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
-					<?php echo esc_html( $description ); ?>
+					<?php echo esc_html( $alongside_text ); ?>
 				</label>
 				<?php
 
@@ -134,8 +134,8 @@ class Settings {
 					echo wp_kses( "<span class='wpsmtp-badge wpsmtp-badge-info'>{$value->source}</span>", [ 'span' => [ 'class' => [] ] ] );
 				}
 
-				if ( ! empty( $subtext ) ) {
-					echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
+				if ( ! empty( $description ) ) {
+					echo wp_kses( $description, [ 'p' => [ 'class' => [] ] ] );
 				}
 			},
 			$this->page,
@@ -150,7 +150,7 @@ class Settings {
 	 * Generates a settings area for multiple checkbox placements.
 	 *
 	 * @param string   $name        Code name of input.
-	 * @param string   $name_pretty Name shown to user.
+	 * @param string   $name_pretty Left-side column name shown to user.
 	 * @param callback $callback    Function is called within the fieldest.
 	 */
 	public function generate_checkbox_area( $name, $name_pretty, $callback ) {
@@ -172,14 +172,14 @@ class Settings {
 	/**
 	 * Generates a checkbox without WordPress settings API for use within generate_checkbox_area callback.
 	 *
-	 * @param string $name        Code name of input.
-	 * @param string $name_pretty Name shown to user.
-	 * @param string $subtext     Text displayed underneath input box.
+	 * @param string $name           Code name of input.
+	 * @param string $alongside_text Appears alongside the checkbox. Required to help identify the field in the collective.
+	 * @param string $description    Text displayed underneath the input box.
 	 */
-	public function generate_checkbox( $name, $name_pretty, $subtext = '' ) {
-		$value   = $this->options->get( $name, true, $this->ms );
-		$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
-		$has_env = '';
+	public function generate_checkbox( $name, $alongside_text, $description = '' ) {
+		$value       = $this->options->get( $name, true, $this->ms );
+		$description = ( ! empty( $description ) ) ? "<p class='description'>{$description}</p>" : '';
+		$has_env     = '';
 		if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 			$has_env = 'disabled';
 		}
@@ -192,8 +192,8 @@ class Settings {
 		?>
 		<label for='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]'>
 			<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
-			<?php echo esc_html( $name_pretty ); ?> <?php echo wp_kses( $debuginfo, [ 'span' => [ 'class' => [] ] ] ); ?>
-			<?php echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] ); ?>
+			<?php echo esc_html( $alongside_text ); ?> <?php echo wp_kses( $debuginfo, [ 'span' => [ 'class' => [] ] ] ); ?>
+			<?php echo wp_kses( $description, [ 'p' => [ 'class' => [] ] ] ); ?>
 		</label><br>
 		<?php
 	}
@@ -202,19 +202,19 @@ class Settings {
 	 * Generates an generic input multi-select.
 	 *
 	 * @param string $name        Code name of input.
-	 * @param string $name_pretty Name shown to user.
+	 * @param string $name_pretty Left-side column name shown to user.
 	 * @param array  $options     Array of possible selections, with the index used as a key.
-	 * @param string $subtext     Text displayed underneath input box.
+	 * @param string $description Text displayed underneath the input box.
 	 */
-	public function generate_selection( $name, $name_pretty, $options, $subtext = '' ) {
+	public function generate_selection( $name, $name_pretty, $options, $description = '' ) {
 		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $value, $options, $subtext ) {
-				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
-				$has_env = '';
+			function () use ( $name, $value, $options, $description ) {
+				$description = ( ! empty( $description ) ) ? "<p class='description'>{$description}</p>" : '';
+				$has_env     = '';
 				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
 					$has_env = 'disabled';
 				}
@@ -226,7 +226,7 @@ class Settings {
 					<?php endforeach; ?>
 				</select>
 				<?php
-				echo wp_kses( $subtext, [ 'p' => [ 'class' => [] ] ] );
+				echo wp_kses( $description, [ 'p' => [ 'class' => [] ] ] );
 			},
 			$this->page,
 			$this->section,

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -106,16 +106,17 @@ class Settings {
 	 * Generates an generic input box.
 	 *
 	 * @param string $name        Code name of input.
-	 * @param string $name_pretty Name shown to user.
+	 * @param string $name_pretty Left-hand column name shown to user.
+	 * @param string $description Appears alongside the checkbox.
 	 * @param string $subtext     Text displayed underneath input box.
 	 */
-	public function generate_unique_checkbox( $name, $name_pretty, $subtext = '' ) {
+	public function generate_unique_checkbox( $name, $name_pretty, $description = '', $subtext = '' ) {
 		$value = $this->options->get( $name, true, $this->ms );
 
 		add_settings_field(
 			'wpssmtp_smtp_' . $name,
 			$name_pretty,
-			function () use ( $name, $value, $subtext ) {
+			function () use ( $name, $description, $value, $subtext ) {
 				$subtext = ( ! empty( $subtext ) ) ? "<p class='description'>{$subtext}</p>" : '';
 				$has_env = '';
 				if ( ! $this->ms && 'CONFIG' !== $value->source ) {
@@ -123,7 +124,10 @@ class Settings {
 				}
 
 				?>
-				<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
+				<label for="wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]">
+					<input id='wpss_<?php echo esc_attr( $name ); ?>' type='checkbox' name='wpssmtp_smtp[<?php echo esc_attr( $name ); ?>]' <?php checked( $value->value, 1 ); ?> value='1' <?php echo esc_attr( $has_env ); ?>>
+					<?php echo esc_html( $description ); ?>
+				</label>
 				<?php
 
 				if ( ! $this->ms && defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -147,7 +147,7 @@ class Singular extends Settings {
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
 		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
-		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
+		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail sender name', 'simple-smtp' ), '', true );
 		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
 		$this->generate_checkbox_area(
 			'adt',

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -146,14 +146,14 @@ class Singular extends Settings {
 		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
-		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
-		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
+		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
+		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
 		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
 		$this->generate_checkbox_area(
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, no emails will be sent from this site.' ,'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, no emails will be sent from this site.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'log', __( 'Log all sent emails to the database', 'simple-smtp' ), __( 'Works with the WordPress privacy features.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}
@@ -194,7 +194,7 @@ class Singular extends Settings {
 			__( 'HTML Mode', 'simple-smtp' ),
 			function () {
 				?>
-				<label for="wpssmtp_test_email_is_html">
+				<label for='wpssmtp_test_email_is_html'>
 					<input id='wpss_test_html' type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
 					<?php esc_html_e( 'Send the test email with HTML content instead of plain text', 'simple-smtp' ); ?>
 				</label>

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -143,15 +143,21 @@ class Singular extends Settings {
 
 		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
 		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->generate_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '' );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '' );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
 		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
 		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
 		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
-		$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
-		$this->generate_checkbox( 'disable', __( 'Disable Emails', 'simple-smtp' ), '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ) );
-		$this->generate_checkbox( 'log', __( 'Logging', 'simple-smtp' ) );
+		$this->generate_checkbox_area(
+			'adt',
+			__( 'Options', 'simple-smtp' ),
+			function() {
+				$this->generate_checkbox( 'disable', __( 'Disable email services.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Enable logging capabilities.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced).', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+			}
+		);
 	}
 
 	/**

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -172,12 +172,15 @@ class Singular extends Settings {
 			__( 'Email recipient', 'simple-smtp' ),
 			function () {
 				?>
-				<input class='regular-text ltr' type='text' name='wpssmtp_test_email_recipient' value='<?php echo esc_attr( wp_get_current_user()->user_email ); ?>'>
+				<input id='wpss_test_recipient' class='regular-text ltr' type='text' name='wpssmtp_test_email_recipient' value='<?php echo esc_attr( wp_get_current_user()->user_email ); ?>'>
 				<p class='description'><?php esc_html_e( 'Separate multiple emails with a semi-colon (;).', 'simple-smtp' ); ?></p>
 				<?php
 			},
 			'wpsimplesmtp_smtp_test',
-			'wpsimplesmtp_test_email'
+			'wpsimplesmtp_test_email',
+			[
+				'label_for' => 'wpss_test_recipient',
+			]
 		);
 
 		add_settings_field(
@@ -185,11 +188,14 @@ class Singular extends Settings {
 			__( 'HTML Mode', 'simple-smtp' ),
 			function () {
 				?>
-				<input type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
+				<input id='wpss_test_html' type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
 				<?php
 			},
 			'wpsimplesmtp_smtp_test',
-			'wpsimplesmtp_test_email'
+			'wpsimplesmtp_test_email',
+			[
+				'label_for' => 'wpss_test_html',
+			]
 		);
 	}
 

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -143,7 +143,7 @@ class Singular extends Settings {
 
 		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
 		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '' );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password.', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
 		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
@@ -194,7 +194,10 @@ class Singular extends Settings {
 			__( 'HTML Mode', 'simple-smtp' ),
 			function () {
 				?>
-				<input id='wpss_test_html' type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
+				<label for="wpssmtp_test_email_is_html">
+					<input id='wpss_test_html' type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
+					<?php esc_html_e( 'Send the test email with HTML content instead of plain text.', 'simple-smtp' ); ?>
+				</label>
 				<?php
 			},
 			'wpsimplesmtp_smtp_test',

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -143,7 +143,7 @@ class Singular extends Settings {
 
 		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
 		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password.', 'simple-smtp' ) );
+		$this->generate_unique_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), __( 'Authenticate connection with username and password', 'simple-smtp' ) );
 		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
 		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
@@ -153,9 +153,9 @@ class Singular extends Settings {
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services.', 'simple-smtp' ) );
-				$this->generate_checkbox( 'log', __( 'Enable logging capabilities.', 'simple-smtp' ) );
-				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced).', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Enable logging capabilities', 'simple-smtp' ) );
+				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}
 		);
 	}
@@ -196,7 +196,7 @@ class Singular extends Settings {
 				?>
 				<label for="wpssmtp_test_email_is_html">
 					<input id='wpss_test_html' type='checkbox' name='wpssmtp_test_email_is_html' value='1'>
-					<?php esc_html_e( 'Send the test email with HTML content instead of plain text.', 'simple-smtp' ); ?>
+					<?php esc_html_e( 'Send the test email with HTML content instead of plain text', 'simple-smtp' ); ?>
 				</label>
 				<?php
 			},

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -153,8 +153,8 @@ class Singular extends Settings {
 			'adt',
 			__( 'Options', 'simple-smtp' ),
 			function() {
-				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ) );
-				$this->generate_checkbox( 'log', __( 'Enable logging capabilities', 'simple-smtp' ) );
+				$this->generate_checkbox( 'disable', __( 'Disable email services', 'simple-smtp' ), __( 'When marked, no emails will be sent from this site.' ,'simple-smtp' ) );
+				$this->generate_checkbox( 'log', __( 'Log all sent emails to the database', 'simple-smtp' ), __( 'Works with the WordPress privacy features.', 'simple-smtp' ) );
 				$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification (advanced)', 'simple-smtp' ), __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
 			}
 		);

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -141,17 +141,17 @@ class Singular extends Settings {
 			'wpsimplesmtp_smtp'
 		);
 
-		$this->settings_field_generator( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
-		$this->settings_field_generator( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
-		$this->settings_field_generator( 'auth', __( 'Authenticate', 'simple-smtp' ), 'checkbox', '' );
-		$this->settings_field_generator( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
-		$this->settings_field_generator( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
-		$this->settings_field_generator( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
-		$this->settings_field_generator( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
-		$this->settings_field_generator_multiple( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), 'dropdown' );
-		$this->settings_field_generator( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), 'checkbox', '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
-		$this->settings_field_generator( 'disable', __( 'Disable Emails', 'simple-smtp' ), 'checkbox', '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ) );
-		$this->settings_field_generator( 'log', __( 'Logging', 'simple-smtp' ), 'checkbox', '' );
+		$this->generate_generic_field( 'host', __( 'Host', 'simple-smtp' ), 'text', 'smtp.example.com' );
+		$this->generate_generic_field( 'port', __( 'Port', 'simple-smtp' ), 'number', '587' );
+		$this->generate_checkbox( 'auth', __( 'Authenticate', 'simple-smtp' ), '' );
+		$this->generate_generic_field( 'user', __( 'Username', 'simple-smtp' ), 'text', 'foobar@example.com' );
+		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
+		$this->generate_generic_field( 'from', __( 'Force from', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
+		$this->generate_generic_field( 'fromname', __( 'Force from name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail address', 'simple-smtp' ), '', true );
+		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
+		$this->generate_checkbox( 'noverifyssl', __( 'Disable SSL Verification', 'simple-smtp' ), '', __( 'Do not disable this unless you know what you\'re doing.', 'simple-smtp' ) );
+		$this->generate_checkbox( 'disable', __( 'Disable Emails', 'simple-smtp' ), '', __( 'Prevents email dispatch on this WordPress site.', 'simple-smtp' ) );
+		$this->generate_checkbox( 'log', __( 'Logging', 'simple-smtp' ) );
 	}
 
 	/**

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Simple SMTP
  * Description:       Adds mail configuration to WordPress in a simple, standardised plugin.
  * Plugin URI:        https://www.soupbowl.io/wp-plugins
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            soup-bowl
  * Author URI:        https://www.soupbowl.io
  * License:           MIT


### PR DESCRIPTION
Issue #51 raised by @kebbet highlights an important oversight that doesn't follow the standard of the rest of the WordPress administration dashboard, being that not only are labels missing from checkboxes, but the label-for in the settings key column were left undefined. 

This PR adjusts the generation functions to make them less of a catch-all approach, and also allows the group of sporadic check boxes to be group together. The PR affects both single-site and multisite settings equally.

@kebbet if you wouldn't mind verifying if this is what you were expecting, especially as it adds more labels that will ultimately need translating and I don't want to add unnecessary burden if it's wrong.

# Settings Checkbox Group
Before
![image](https://user-images.githubusercontent.com/11209477/135719855-77175f03-9c23-419e-93ca-c8b78e77e3cd.png)
After
![image](https://user-images.githubusercontent.com/11209477/135719862-f0d53ecb-2064-461e-ae6f-011dafb345fb.png)

# Additionals
![image](https://user-images.githubusercontent.com/11209477/135719877-5e57511a-1eab-4440-8618-b3510a2a835d.png)
![image](https://user-images.githubusercontent.com/11209477/135719886-1f499efd-3532-48e8-af61-e6c6b28800d5.png)

# Additional adjustments
* Multisite over-ride on settings generation now an inherited trait rather than a function argument.
* Debug setting source indicators use the badges from mail view to help isolate their presences.
