### PR TITLE
Add a filter for max number of entries per log page.

### DIFF
--- a/src/log/class-logtable.php
+++ b/src/log/class-logtable.php
@@ -36,9 +36,10 @@ class LogTable {
 	 * @param integer $maximum_per_page Limits the table display.
 	 */
 	public function display( $page, $maximum_per_page = 5 ) {
-		$page    = ( $page < 0 ) ? 0 : $page;
-		$entries = $this->log_service->get_log_entries( ( $page + 1 ), $maximum_per_page );
-		$pages   = $this->log_service->get_log_entry_pages( $maximum_per_page );
+		$maximum_per_page = apply_filters( 'simple_smtp_log_table_max_per_page', $maximum_per_page );
+		$page             = ( $page < 0 ) ? 0 : $page;
+		$entries          = $this->log_service->get_log_entries( ( $page + 1 ), $maximum_per_page );
+		$pages            = $this->log_service->get_log_entry_pages( $maximum_per_page );
 
 		$labels = [
 			__( 'Recipient(s)', 'simple-smtp' ),


### PR DESCRIPTION
Closes #57 

Sample filter in a theme or mu-plugin.
```php
/**
 * Adjust number of entries in the log table.
 *
 * @author kebbet
 */
function log_table_entries_per_page() {
	return intval( 10 );
}
add_filter( 'simple_smtp_log_table_max_per_page', __NAMESPACE__ . '\log_table_entries_per_page', 10 );
