### PR TITLE
Change Log Viewer Capabilities

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-sim
 
 == Changelog ==
 = Edge =
+* Change: Tightened permissions to the log viewer ([#74](https://github.com/soup-bowl/wp-simple-smtp/issues/74)).
 * Fix: Incorrect capability type used by the log viewer. Thanks to [Benoît Chantre](https://github.com/benoitchantre) [#74](https://github.com/soup-bowl/wp-simple-smtp/issues/74).
 
 = 1.2.3 =

--- a/src/log/class-logservice.php
+++ b/src/log/class-logservice.php
@@ -36,7 +36,21 @@ class LogService {
 	 * Register the log storage CPT within WordPress.
 	 */
 	public function register_log_storage() {
-		register_post_type( $this->post_type );
+		register_post_type(
+			$this->post_type,
+			[
+				'capabilities' => [
+					'publish_posts'       => 'manage_options',
+					'edit_others_posts'   => 'manage_options',
+					'delete_posts'        => 'manage_options',
+					'delete_others_posts' => 'manage_options',
+					'read_private_posts'  => 'manage_options',
+					'edit_post'           => 'manage_options',
+					'delete_post'         => 'manage_options',
+					'read_post'           => 'manage_options',
+				],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Suggested by @benoitchantre from Issue #74. The capabilities are left to default, which leaves the permissions at mercy to the default interpretation (being a post). This gives unintentionally liberal permissions to lower user types. Fine in most use cases (could impact people using permissions customisers?), but exhibits a lack of control.

Setting the permissions to [`manage_options`](https://wordpress.org/support/article/roles-and-capabilities/#manage_options) restricts the post type capabilities to the permission type that permits.

Testing steps taken (repeated for Multisite):
- [x] Send a test email.
- [x] Reset a non-admin user account.
- [x] Register on front-end.
  - [x]  Then also reset the password again.
- [x] WP-CLI can send test email.