### PR TITLE
Consolidate Quick Config into plugin

### DIFF
--- a/assets/smtp-config.js
+++ b/assets/smtp-config.js
@@ -13,15 +13,10 @@ const { __, _x, _n, _nx } = wp.i18n;
  */
 function wpss_loadin() {
 	if ( null !== document.getElementById( 'wpss-conf' ) ) {
-		jQuery.getJSON(
-			"https://www.soupbowl.io/wp-json/wprass/v1/sources",
-			function( data ) {
-				wpss_load_quicksettings( data );
-				document.getElementById( 'wpss-quickset' ).onchange = function( stuff ) {
-					wpss_input_selection( data, stuff.target.value );
-				};
-			}
-		);
+		wpss_load_quicksettings( wpss_qc_settings );
+		document.getElementById( 'wpss-quickset' ).onchange = function( stuff ) {
+			wpss_input_selection( wpss_qc_settings, stuff.target.value );
+		};
 	}
 }
 
@@ -47,10 +42,10 @@ function wpss_load_quicksettings( data ) {
 	selector_c1.outerHTML = "<th scope=\"row\">" + __( 'Quick Config', 'simple-smtp' ) + "</th>";
 
 	// Content cell.
-	var datacount = data.configurations.length;
+	var datacount = data.length;
 	options      += '<option>' + __( 'Select', 'simple-smtp' ) + '</option>';
 	for (i = 0; i < datacount; i++) {
-		options += '<option>' + data.configurations[i].name + '</option>';
+		options += '<option>' + data[i].name + '</option>';
 	}
 	selector.innerHTML = options;
 	selector_c2.appendChild( selector );
@@ -69,10 +64,10 @@ function wpss_load_quicksettings( data ) {
  */
 function wpss_input_selection( data, name ) {
 	var s = null;
-	var c = data.configurations.length;
+	var c = data.length;
 	for (i = 0; i < c; i++) {
-		if ( data.configurations[i].name == name ) {
-			s = data.configurations[i];
+		if ( data[i].name == name ) {
+			s = data[i];
 			break;
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-sim
 
 == Changelog ==
 = Edge =
+* Change: Quick config settings now contained within plugin ([#78](https://github.com/soup-bowl/wp-simple-smtp/issues/78)).
 * Fix: Incorrect capability type used by the log viewer. Thanks to [Benoît Chantre](https://github.com/benoitchantre) [#74](https://github.com/soup-bowl/wp-simple-smtp/issues/74).
 
 = 1.2.3 =

--- a/src/settings/class-quickconfig.php
+++ b/src/settings/class-quickconfig.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Simple email configuration within WordPress.
+ *
+ * @package sb-simple-smtp
+ * @author soup-bowl <code@soupbowl.io>
+ * @license MIT
+ */
+
+namespace wpsimplesmtp;
+
+/**
+ * Configuration applicable to the quick config segment.
+ */
+class QuickConfig {
+	/**
+	 * Returns an array of possible SMTP configuration options.
+	 *
+	 * @return array
+	 */
+	public static function settings() {
+		return [
+			[
+				'name'           => 'Gmail',
+				'server'         => 'smtp.gmail.com',
+				'port'           => '587',
+				'authentication' => true,
+				'encryption'     => 'tls',
+			],
+			[
+				'name'           => 'Microsoft Exchange',
+				'server'         => 'smtp.office365.com',
+				'port'           => '587',
+				'authentication' => true,
+				'encryption'     => 'tls',
+			],
+			[
+				'name'           => 'SendGrid',
+				'server'         => 'smtp.sendgrid.net',
+				'port'           => '587',
+				'authentication' => true,
+				'user'           => 'apikey',
+				'encryption'     => 'tls',
+			],
+			[
+				'name'           => 'Pepipost',
+				'server'         => 'smtp.pepipost.com',
+				'port'           => '587',
+				'authentication' => true,
+			],
+			[
+				'name'           => 'SendinBlue',
+				'server'         => 'smtp-relay.sendinblue.com',
+				'port'           => '587',
+				'authentication' => true,
+			],
+			[
+				'name'           => 'Amazon SES',
+				'server'         => 'email-smtp.<CHANGE>.amazonaws.com',
+				'port'           => '465',
+				'authentication' => true,
+				'encryption'     => 'tls',
+			],
+		];
+	}
+}

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -71,6 +71,52 @@ add_action(
 			wp_enqueue_style( 'wpss_admin_css', plugin_dir_url( __FILE__ ) . 'assets/smtp-config.css', [], '1.2' );
 			wp_enqueue_script( 'wpss_config', plugin_dir_url( __FILE__ ) . 'assets/smtp-config.js', [ 'jquery', 'wp-i18n' ], '1.3', true );
 			wp_set_script_translations( 'wpss_config', 'simple-smtp' );
+
+			$smtp_settings = [
+				[
+					'name'           => 'Gmail',
+					'server'         => 'smtp.gmail.com',
+					'port'           => '587',
+					'authentication' => true,
+					'encryption'     => 'tls',
+				],
+				[
+					'name'           => 'Microsoft Exchange',
+					'server'         => 'smtp.office365.com',
+					'port'           => '587',
+					'authentication' => true,
+					'encryption'     => 'tls',
+				],
+				[
+					'name'           => 'SendGrid',
+					'server'         => 'smtp.sendgrid.net',
+					'port'           => '587',
+					'authentication' => true,
+					'user'           => 'apikey',
+					'encryption'     => 'tls',
+				],
+				[
+					'name'           => 'Pepipost',
+					'server'         => 'smtp.pepipost.com',
+					'port'           => '587',
+					'authentication' => true,
+				],
+				[
+					'name'           => 'SendinBlue',
+					'server'         => 'smtp-relay.sendinblue.com',
+					'port'           => '587',
+					'authentication' => true,
+				],
+				[
+					'name'           => 'Amazon SES',
+					'server'         => 'email-smtp.<CHANGE>.amazonaws.com',
+					'port'           => '465',
+					'authentication' => true,
+					'encryption'     => 'tls',
+				],
+			];
+
+			wp_localize_script( 'wpss_config', 'wpss_qc_settings', $smtp_settings );
 		}
 	}
 );

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -19,6 +19,7 @@
 use wpsimplesmtp\LogService;
 use wpsimplesmtp\Singular as Settings;
 use wpsimplesmtp\Multisite as SettingsMultisite;
+use wpsimplesmtp\QuickConfig;
 use wpsimplesmtp\Privacy;
 use wpsimplesmtp\Mail;
 use wpsimplesmtp\MailDisable;
@@ -72,49 +73,7 @@ add_action(
 			wp_enqueue_script( 'wpss_config', plugin_dir_url( __FILE__ ) . 'assets/smtp-config.js', [ 'jquery', 'wp-i18n' ], '1.3', true );
 			wp_set_script_translations( 'wpss_config', 'simple-smtp' );
 
-			$smtp_settings = [
-				[
-					'name'           => 'Gmail',
-					'server'         => 'smtp.gmail.com',
-					'port'           => '587',
-					'authentication' => true,
-					'encryption'     => 'tls',
-				],
-				[
-					'name'           => 'Microsoft Exchange',
-					'server'         => 'smtp.office365.com',
-					'port'           => '587',
-					'authentication' => true,
-					'encryption'     => 'tls',
-				],
-				[
-					'name'           => 'SendGrid',
-					'server'         => 'smtp.sendgrid.net',
-					'port'           => '587',
-					'authentication' => true,
-					'user'           => 'apikey',
-					'encryption'     => 'tls',
-				],
-				[
-					'name'           => 'Pepipost',
-					'server'         => 'smtp.pepipost.com',
-					'port'           => '587',
-					'authentication' => true,
-				],
-				[
-					'name'           => 'SendinBlue',
-					'server'         => 'smtp-relay.sendinblue.com',
-					'port'           => '587',
-					'authentication' => true,
-				],
-				[
-					'name'           => 'Amazon SES',
-					'server'         => 'email-smtp.<CHANGE>.amazonaws.com',
-					'port'           => '465',
-					'authentication' => true,
-					'encryption'     => 'tls',
-				],
-			];
+			$smtp_settings = QuickConfig::settings();
 
 			wp_localize_script( 'wpss_config', 'wpss_qc_settings', $smtp_settings );
 		}


### PR DESCRIPTION
Regarding #78 - The Quick Config widget has failed due to a change in endpoint. This PR brings the quick config settings source into the plugin as a point-of-truth, rather than relying on an external endpoint.

Changes in endpoint suggestions have been low/none, proving the endpoint to not be necessary. However, the SMTP configuration has been split onto a static function to help assist PRs incoming from non-PHP people.