### PR TITLE
Feedback when testing emails.

### DIFF
--- a/src/cli/class-emailtest.php
+++ b/src/cli/class-emailtest.php
@@ -41,9 +41,9 @@ class EmailTest {
 			$is_sent = wp_mail( $recipient, $email['subject'], $email['message'], $email['headers'] );
 
 			if ( $is_sent ) {
-				WP_CLI::success( __( 'Test email sent!', 'simple-smtp' ) );
+				WP_CLI::success( __( 'Test email sent successfully.', 'simple-smtp' ) );
 			} else {
-				WP_CLI::error( __( 'Email failed to send. Check the logs to see what happened.', 'simple-smtp' ) );
+				WP_CLI::error( __( 'Test email failed. Please check your configuration and try again.', 'simple-smtp' ) );
 			}
 		} else {
 			WP_CLI::error( __( 'Email address provided is invalid.', 'simple-smtp' ) );

--- a/src/mail/class-mailtest.php
+++ b/src/mail/class-mailtest.php
@@ -90,9 +90,16 @@ class Mailtest {
 				$recipients[ $i ] = sanitize_email( trim( $recipients[ $i ] ) );
 			}
 
-			wp_mail( $recipients, $email['subject'], $email['message'], $email['headers'] );
+			$success = wp_mail( $recipients, $email['subject'], $email['message'], $email['headers'] );
 
-			wp_safe_redirect( admin_url( 'options-general.php?page=wpsimplesmtp' ) );
+			wp_safe_redirect(
+				add_query_arg(
+					[
+						'status' => ( $success ) ? 'pass' : 'fail',
+					],
+					admin_url( 'options-general.php?page=wpsimplesmtp' )
+				)
+			);
 			exit;
 		} else {
 			wp_die( esc_attr_e( 'You are not permitted to send a test email.', 'simple-smtp' ) );

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -257,6 +257,23 @@ class Singular extends Settings {
 			<?php if ( $this->can_edit_settings( 'wpssmtp_disable_settings' ) ) : ?>
 				<form id='wpss-conf' action='options.php' method='post'>
 					<?php
+					if ( ! empty( $_REQUEST['status'] ) ) {
+						$has_pass     = ( 'pass' === $_REQUEST['status'] ) ? true : false;
+						$notice_level = ( $has_pass ) ? 'notice-success' : 'notice-error';
+						$notice       = ( $has_pass ) ? __( 'Test email sent successfully.', 'simple-smtp' ) : __( 'Test email failed. Please check your configuration and try again.', 'simple-smtp' );
+
+						echo wp_kses(
+							"<div class='notice is-dismissible {$notice_level}'><p><strong>{$notice}</strong></p></div>",
+							[
+								'div'    => [
+									'class' => [],
+								],
+								'p'      => [],
+								'strong' => [],
+							]
+						);
+					}
+
 					settings_fields( 'wpsimplesmtp_smtp' );
 					do_settings_sections( 'wpsimplesmtp_smtp' );
 					submit_button();


### PR DESCRIPTION
(Addresses #81).

On success:
![](https://user-images.githubusercontent.com/11209477/149646396-8273e951-c62b-4b69-b7ee-418462030735.png)

On failure:
![](https://user-images.githubusercontent.com/11209477/149646395-3b5c23dd-380f-42b7-89f7-0f384229582c.png)

This also adjusts the **WP-CLI responses** to match - so they can share the same response translation.
