### PR TITLE
Deploy a ZIP alongside a release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to WordPress.org
 on:
-  push:
-    tags:
-    - "*"
+  release:
+    types: [published]
 jobs:
   tag:
     name: New tag
@@ -16,8 +15,19 @@ jobs:
         dev: no
         args: --profile --ignore-platform-reqs
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: simple-smtp
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ steps.deploy.outputs.zip-path }}
+        asset_name: ${{ github.event.repository.name }}.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
Adjustment based on the [10up deployment method](https://github.com/marketplace/actions/wordpress-plugin-deploy) recommendations to deploy with a zip on GitHub releases as well as an upload to WordPress.org.

Tagged as part of #69, but does not close the issue as it only adjusts infrastructure to meet the needs. Further work needs to be done to support GitHub installations.