### PR TITLE
Fix infinite logging loop when a service inspects the mail service

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
       docker pull composer
       docker-compose pull
       docker-compose build www
-    command: sh ./.devcontainer/postCreateCommand.sh 
+    command: sh ./.devcontainer/postCreateCommand.sh
 vscode:
   extensions:
     - ms-azuretools.vscode-docker

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,9 @@ To help diagnose disabled input boxes, when the WordPress site is in [debugging 
 Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-simple-smtp) for writing issues and/or making pull requests.
 
 == Changelog ==
+= Unreleased =
+* Fix: Infinite loop when a plugin hooks into the mail routine functions and sends an email ([#116](https://github.com/soup-bowl/wp-simple-smtp/pull/116)).
+
 = 1.3.1 =
 * Added: Glance view on the dashboard to see mail usage (Thanks [Kebbet](https://github.com/kebbet) - [PR 101](https://github.com/soup-bowl/wp-simple-smtp/pull/101), [PR 102](https://github.com/soup-bowl/wp-simple-smtp/pull/102)).
 * Fix: Table view appears correctly on mobile (Thanks [Kebbet](https://github.com/kebbet) - [PR 93](https://github.com/soup-bowl/wp-simple-smtp/pull/93)).

--- a/src/log/class-logservice.php
+++ b/src/log/class-logservice.php
@@ -60,6 +60,12 @@ class LogService {
 	 * @return integer ID of the newly-inserted entry.
 	 */
 	public function new_log_entry( $log ) {
+		// Patch fix to stop Sucuri from spamming the log. Should be investigated more.
+		$dup_check = post_exists( $log->get_subject(), '', current_time( 'mysql' ), $this->post_type );
+		if ( 0 !== $dup_check ) {
+			return $dup_check;
+		}
+
 		$post_id = wp_insert_post(
 			[
 				'post_title'   => $log->get_subject(),


### PR DESCRIPTION
From my quick approximation, it looks like from #115 some plugins injecting code to check dispatched emails can also send an email, triggering an infinite loop of logging that stops when the PHP function call limit is hit.

This hotfix checks if an email has already been dispatched before creating a new log entry, which should stop runaway logging before it happens. Needs further testing.