### PR TITLE
WordPress 6.0 Verification Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: soupbowl
 Tags: mail,email,smtp,dispatch,sender
 Requires at least: 4.9
-Tested up to: 5.9
+Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 1.3.1
+Stable tag: 1.3.1.1
 License: MIT
 
 Adds a simple mail configuration panel into your WordPress installation. Supports temporary logging and config variables.
@@ -96,6 +96,9 @@ To help diagnose disabled input boxes, when the WordPress site is in [debugging 
 Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-simple-smtp) for writing issues and/or making pull requests.
 
 == Changelog ==
+= 1.3.1.1 =
+* Verified working with WordPress 6.0.
+
 = 1.3.1 =
 * Added: Glance view on the dashboard to see mail usage (Thanks [Kebbet](https://github.com/kebbet) - [PR 101](https://github.com/soup-bowl/wp-simple-smtp/pull/101), [PR 102](https://github.com/soup-bowl/wp-simple-smtp/pull/102)).
 * Fix: Table view appears correctly on mobile (Thanks [Kebbet](https://github.com/kebbet) - [PR 93](https://github.com/soup-bowl/wp-simple-smtp/pull/93)).

--- a/wp-simple-smtp.php
+++ b/wp-simple-smtp.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Simple SMTP
  * Description:       Adds mail configuration to WordPress in a simple, standardised plugin.
  * Plugin URI:        https://github.com/soup-bowl/wp-simple-smtp
- * Version:           1.3.1
+ * Version:           1.3.1.1
  * Author:            soup-bowl & Contributors
  * Author URI:        https://github.com/soup-bowl/wp-simple-smtp
  * License:           MIT


### PR DESCRIPTION
This PR bumps the requirement flag to WordPress 6.0 (#112). The plugin has been tested and works on the current version, with the PHP Mailer testing library already matching the PHPMailer deployment version that 6.0 is being released with.

This is purely a release to verify the version - no codebase changes have occurred.