### PR TITLE
Fix headers information not displayed

### DIFF
--- a/src/log/class-log.php
+++ b/src/log/class-log.php
@@ -165,9 +165,18 @@ class Log {
 	 */
 	public function get_headers_as_array( $exclude_recipients = true ) {
 		$collection = [];
-		if ( ! empty( $this->get_headers() ) ) {
-			foreach ( $this->get_headers() as $header ) {
+		$_headers = explode( 'rn', $this->get_headers() );
+
+		if ( ! empty( $_headers ) ) {
+			foreach ( $_headers as $header ) {
+				// Last caracters of the headers are always rn.
+				if ( empty( $header ) ) {
+					continue;
+				}
+
 				$expd = explode( ':', $header );
+				$expd = array_map( 'trim', $expd );
+
 				if ( $exclude_recipients && in_array( strtolower( $expd[0] ), [ 'cc', 'bcc', 'from' ], true ) ) {
 					continue;
 				} else {

--- a/src/log/class-log.php
+++ b/src/log/class-log.php
@@ -165,7 +165,7 @@ class Log {
 	 */
 	public function get_headers_as_array( $exclude_recipients = true ) {
 		$collection = [];
-		$_headers = explode( 'rn', $this->get_headers() );
+		$_headers   = explode( 'rn', $this->get_headers() );
 
 		if ( ! empty( $_headers ) ) {
 			foreach ( $_headers as $header ) {


### PR DESCRIPTION
When logs are enabled, the information box should display the email headers. This was not the case.

Closes #114.