### PR TITLE
Add none/off encryption setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ These can be either stored in your systems env setup, or in wp-config.php as `de
 * `SMTP_PASS` (string) The password for the mailer account.
 * `SMTP_FROM` (string) Enforce all emails come from this email address.
 * `SMTP_FROMNAME` (string) Enforce all emails to have a certain email name.
-* `SMTP_SEC` (string) Use a particular email security method (accepts 'def' (default), 'ssl' and 'tls').
+* `SMTP_SEC` (string) Use a particular email security method (accepts 'def' (default), 'ssl', 'tls' and 'off').
 * `SMTP_NOVERIFYSSL` (boolean) Disable validation of the SMTP server certificate (not recommended).
 * `SMTP_LOG` (boolean) Controls the logging capability and visibility.
 * `SMTP_DISABLE` (boolean) Disables the mailer. They will still be logged if enabled, but won't send out.
@@ -104,6 +104,9 @@ Yes! [Please see our GitHub repository here](https://github.com/soup-bowl/wp-sim
 One of the easiest aspects to contribute to is the SMTP quick configuration segment. If you wish to maintain this aspect, suggest a new setting, or report broken entries, see the [SMTP quick config wiki page](https://github.com/soup-bowl/wp-simple-smtp/wiki/SMTP-Quick-Config).
 
 == Changelog ==
+= Unreleased =
+* Added: None encryption setting ([#148](https://github.com/soup-bowl/wp-simple-smtp/issues/148)).
+
 = 1.3.2.2 =
 * Verified working with WordPress 6.1 and 6.2.
 * Fix: PHP warning on the CLI interface ([#140](https://github.com/soup-bowl/wp-simple-smtp/issues/140)).

--- a/src/mail/class-mail.php
+++ b/src/mail/class-mail.php
@@ -88,6 +88,8 @@ class Mail {
 			$sec = $this->options->get( 'sec' );
 			if ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'ssl', 'tls' ], true ) ) {
 				$phpmailer->SMTPSecure = $sec->value;
+			} elseif ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'off' ], true ) )  {
+				$phpmailer->SMTPAutoTLS = false;
 			}
 
 			$ssl_status = $this->options->get( 'noverifyssl' );

--- a/src/mail/class-mail.php
+++ b/src/mail/class-mail.php
@@ -88,7 +88,7 @@ class Mail {
 			$sec = $this->options->get( 'sec' );
 			if ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'ssl', 'tls' ], true ) ) {
 				$phpmailer->SMTPSecure = $sec->value;
-			} elseif ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'off' ], true ) )  {
+			} elseif ( ! empty( $sec ) && in_array( (string) $sec->value, [ 'off' ], true ) ) {
 				$phpmailer->SMTPAutoTLS = false;
 			}
 

--- a/src/settings/class-multisite.php
+++ b/src/settings/class-multisite.php
@@ -78,7 +78,7 @@ class Multisite extends Settings {
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password' );
 		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
 		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail sender name', 'simple-smtp' ) );
-		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
+		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), __( 'Disabling this may risk email security.', 'simple-smtp' ) );
 		$this->generate_checkbox_area(
 			'adt',
 			__( 'Options', 'simple-smtp' ),

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -66,6 +66,7 @@ class Settings {
 			'def' => __( 'Default', 'simple-smtp' ),
 			'ssl' => __( 'SSL', 'simple-smtp' ),
 			'tls' => __( 'TLS', 'simple-smtp' ),
+			'off' => __( 'None', 'simple-smtp' ),
 		];
 	}
 

--- a/src/settings/class-singular.php
+++ b/src/settings/class-singular.php
@@ -162,7 +162,7 @@ class Singular extends Settings {
 		$this->generate_generic_field( 'pass', __( 'Password', 'simple-smtp' ), 'password', '' );
 		$this->generate_generic_field( 'from', __( 'Force from e-mail address', 'simple-smtp' ), 'email', 'do-not-reply@example.com' );
 		$this->generate_generic_field( 'fromname', __( 'Force from e-mail sender name', 'simple-smtp' ), 'text', _x( 'WordPress System', 'Force from e-mail sender name', 'simple-smtp' ), '', true );
-		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types() );
+		$this->generate_selection( 'sec', __( 'Security', 'simple-smtp' ), $this->acceptable_security_types(), __( 'Disabling this may risk email security.', 'simple-smtp' ) );
 		$this->generate_checkbox_area(
 			'adt',
 			__( 'Options', 'simple-smtp' ),


### PR DESCRIPTION
![](https://github.com/soup-bowl/wp-simple-smtp/assets/11209477/5f0801f0-c7c7-4321-8246-68f9a71692b7)

Added a none/off encryption settings that turns off SSL encryption, and also disables the automatic checks.

A disclaimer is added to the dropdown:

> Disabling this may risk email security.