### PR TITLE
Pipeline replacement for asset upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     name: New tag
@@ -28,12 +31,8 @@ jobs:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: simple-smtp
 
-#    - name: Upload release asset
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ github.event.release.upload_url }}
-#        asset_path: ${{ steps.deploy.outputs.zip-path }}
-#        asset_name: ${{ github.event.repository.name }}.zip
-#        asset_content_type: application/zip
+    - name: Upload release asset
+      run: |
+        gh release upload ${{ github.event.release.tag_name }} ${{ steps.deploy.outputs.zip-path }} --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces the deprecated marketplace action with a GitHub CLI equivalent command.