### PR TITLE
Verify post type before executing delete

### DIFF
--- a/src/log/class-logservice.php
+++ b/src/log/class-logservice.php
@@ -200,7 +200,9 @@ class LogService {
 		);
 
 		foreach ( $all as $log ) {
-			wp_delete_post( $log->ID );
+			if ( $log->post_type === $this->post_type ) {
+				wp_delete_post( $log->ID );
+			}
 		}
 
 		return true;
@@ -224,7 +226,9 @@ class LogService {
 		);
 
 		foreach ( $all as $log ) {
-			wp_delete_post( $log->ID );
+			if ( $log->post_type === $this->post_type ) {
+				wp_delete_post( $log->ID );
+			}
 		}
 
 		return true;
@@ -254,7 +258,9 @@ class LogService {
 		// @phpcs:enable
 
 		foreach ( $all as $log ) {
-			wp_delete_post( $log->ID );
+			if ( $log->post_type === $this->post_type ) {
+				wp_delete_post( $log->ID );
+			}
 		}
 
 		return count( $all );


### PR DESCRIPTION
Seems like in some unfortunate scenarios, the loop before a deletion can end up with some posts that escape the search results. This change adds a check of valid post type before running a deletion.

To be absolutely sure, I've also added the check to all instances of `wp_delete_post`. Should be fine in the other scenarios, but this was fine... I don't want to leave it to chance.